### PR TITLE
docs: Add Perplexity API key configuration to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,12 @@ NEXT_PUBLIC_LOGO_DEV_KEY=your-logo-dev-public-key
 # Get your API key from https://console.anthropic.com/
 ANTHROPIC_API_KEY=your-anthropic-api-key
 
+# Perplexity API key for company discovery and URL search
+# Get your API key from https://www.perplexity.ai/settings/api
+# Used for: AI-powered company discovery, searching LinkedIn/Glassdoor/Crunchbase URLs
+# Requires prepaid credits ($10-$20 minimum)
+PERPLEXITY_API_KEY=your-perplexity-api-key
+
 # =============================================================================
 # E2E TEST CONFIGURATION (Optional - for automated testing)
 # =============================================================================


### PR DESCRIPTION
## Summary
- Added `PERPLEXITY_API_KEY` environment variable documentation to `.env.example`
- Included setup instructions and usage description
- Noted requirement for prepaid credits ($10-$20 minimum)

## Context
During manual testing, discovered that Perplexity API key is required for:
- AI-powered company discovery
- Searching for company URLs (LinkedIn, Glassdoor, Crunchbase)

This configuration was missing from `.env.example`, making it difficult for new developers to discover and set up this optional but useful feature.

## What Changed
Added the following to `.env.example`:
```bash
# Perplexity API key for company discovery and URL search
# Get your API key from https://www.perplexity.ai/settings/api
# Used for: AI-powered company discovery, searching LinkedIn/Glassdoor/Crunchbase URLs
# Requires prepaid credits ($10-$20 minimum)
PERPLEXITY_API_KEY=your-perplexity-api-key
```

## Test Plan
- [x] Updated `.env.example` with clear documentation
- [x] Verified format matches existing entries
- [x] No code changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)