### PR TITLE
Fix: Center toast notifications under Explore/Watchlist tabs

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -189,9 +189,9 @@ span.rounded-full.text-white[style*="background"] {
 }
 
 /* Sonner toast positioning - center horizontally to match Explore/Watchlist tabs */
-/* Tabs are centered in the left graph container (flex-1), so position at 25% of viewport */
+/* Tabs are centered at 50% of viewport with left-1/2 transform -translate-x-1/2 */
 [data-sonner-toaster][data-position="top-center"] {
-  left: 25% !important;
+  left: 50% !important;
   transform: translateX(-50%) !important;
 }
 
@@ -270,245 +270,245 @@ span.text-lg.font-bold.px-3.py-1.rounded-full.text-white {
 /* Apply to most laptop displays and smaller */
 @media (max-width: 1920px) {
   /* Directly target Tailwind classes to make elements smaller */
-  
+
   /* CMF Panel - make smaller */
   .w-80 {
     width: 18rem; /* reduce from 20rem */
   }
-  
-  /* Company Detail Panel - make narrower */  
+
+  /* Company Detail Panel - make narrower */
   .w-96 {
     width: 20rem; /* reduce from 24rem */
   }
-  
+
   /* Navigation buttons - make narrower */
   .w-56 {
     width: 12rem; /* reduce from 14rem */
   }
-  
+
   /* Reduce padding on buttons */
   .px-4.py-3 {
     padding: 0.625rem 0.875rem;
   }
-  
+
   /* Reduce some spacing */
   .space-y-6 > * + * {
     margin-top: 1.25rem; /* reduce from 1.5rem */
   }
-  
+
   .p-6 {
     padding: 1.25rem; /* reduce from 1.5rem */
   }
-  
+
   /* Make logos slightly smaller */
   .w-12.h-12 {
     width: 2.5rem;
     height: 2.5rem;
   }
-  
+
   /* Font size adjustments for better proportions */
-  
+
   /* Company Detail Panel - reduce font sizes */
   .text-xl {
     font-size: 1.125rem; /* down from 1.25rem */
   }
-  
+
   .text-lg {
     font-size: 1rem; /* down from 1.125rem */
   }
-  
+
   .text-sm {
     font-size: 0.8125rem; /* down from 0.875rem */
   }
-  
+
   .text-xs {
     font-size: 0.6875rem; /* down from 0.75rem */
   }
-  
+
   /* Navigation tabs - smaller font */
   button .text-base,
   button span {
     font-size: 0.875rem !important; /* down from 1rem */
   }
-  
+
   /* CMF Panel - refined font sizes and colors */
   .cmf-panel h3 {
     font-size: 0.875rem; /* keep section titles readable */
     color: #000000 !important; /* make titles black for better hierarchy */
   }
-  
+
   .cmf-panel h4 {
     font-size: 0.8125rem; /* keep subsection titles readable */
     color: #000000 !important; /* make section titles black */
   }
-  
+
   /* Also target the specific classes used in CMF panel */
   .absolute.z-50.w-80 h4.font-medium {
     color: #000000 !important;
   }
-  
+
   .absolute.z-50.w-80 .font-medium.text-gray-700 {
     color: #000000 !important;
   }
-  
+
   /* Force CMF panel bullet points to match company subtitles exactly */
   div[class*="cmf-panel"] span.text-sm.text-gray-600 {
     font-size: 0.6875rem !important; /* force to match text-xs size */
   }
-  
+
   /* More specific override for all CMF text-sm elements */
   .absolute.top-16.left-6 span.text-sm {
     font-size: 0.6875rem !important;
   }
-  
+
   /* Nuclear option - target by position and class combination */
   .absolute.z-50.w-80 .text-sm {
     font-size: 0.6875rem !important;
   }
-  
+
   /* Reduce spacing in CMF panel for more compact layout */
   .absolute.z-50.w-80 .mb-2 {
     margin-bottom: 0.25rem !important; /* reduce from 0.5rem */
   }
-  
+
   .absolute.z-50.w-80 .space-y-3 > * + * {
     margin-top: 1rem !important; /* increase space between sections */
   }
-  
+
   .absolute.z-50.w-80 .space-y-4 > * + * {
     margin-top: 1rem !important; /* increase space between sections */
   }
-  
+
   /* Keep original padding for better visual comfort */
   .absolute.z-50.w-80 .p-3 {
     padding: 0.75rem !important; /* restore original padding */
   }
-  
+
   .absolute.z-50.w-80 .p-4 {
     padding: 1rem !important; /* restore original padding */
   }
-  
+
   /* Backup selectors for CMF content */
   .cmf-panel .space-y-1 span.text-sm {
     font-size: 0.6875rem !important;
   }
-  
+
   /* Target all text-sm in CMF panel */
   .cmf-panel .text-sm {
     font-size: 0.6875rem !important;
   }
-  
+
   /* Target paragraphs in CMF panel */
   .cmf-panel p.text-sm {
     font-size: 0.6875rem !important;
   }
-  
+
   /* Target the experience tags */
   .cmf-panel .px-2.py-1 {
     font-size: 0.625rem; /* even smaller for tags */
     padding: 0.125rem 0.375rem; /* tighter tag padding */
   }
-  
+
   /* General body text adjustments */
   body {
     font-size: 0.9375rem; /* slightly smaller base */
   }
-  
+
   /* Compact company panel spacing */
-  
+
   /* Reduce spacing between company items in the list - more specific selector */
   .panel-content .space-y-3 > * + * {
     margin-top: 0.25rem !important; /* reduce from 0.75rem to very tight */
   }
-  
+
   /* Make company items more compact - target the specific company item divs */
   .panel-content .space-y-3 > div.p-3 {
     padding: 0.375rem !important; /* reduce from 0.75rem to very compact */
   }
-  
+
   /* Alternative approach - target all company list items */
   .panel-content .bg-gray-50.p-3 {
     padding: 0.375rem !important;
     margin-bottom: 0.25rem !important;
   }
-  
+
   /* Reduce spacing in company detail sections */
   .space-y-6 > * + * {
     margin-top: 1rem; /* reduce from 1.5rem */
   }
-  
+
   /* Company logo in list items - make smaller */
   .w-8.h-8 {
     width: 1.75rem; /* reduce from 2rem */
     height: 1.75rem;
   }
-  
+
   .w-6.h-6 {
-    width: 1.25rem; /* reduce from 1.5rem */  
+    width: 1.25rem; /* reduce from 1.5rem */
     height: 1.25rem;
   }
-  
+
   /* Reduce match score badge size */
   .px-2.py-1 {
     padding: 0.25rem 0.5rem; /* reduce from 0.25rem 0.5rem */
   }
-  
+
   /* Compact section spacing in detail view */
   .mb-3 {
     margin-bottom: 0.5rem; /* reduce from 0.75rem */
   }
-  
+
   .mb-2 {
     margin-bottom: 0.375rem; /* reduce from 0.5rem */
   }
-  
+
   /* Reduce space between bullet points */
   .space-y-2 > * + * {
     margin-top: 0.375rem; /* reduce from 0.5rem */
   }
-  
+
   .space-y-1 > * + * {
     margin-top: 0.25rem; /* reduce from 0.25rem - already small */
   }
-  
+
   /* Apply CMF panel styling consistency to company detail view */
   /* Make section titles black and more prominent like CMF panel */
   .company-detail-panel .section-title {
     color: #000000 !important; /* black titles like CMF panel */
   }
-  
+
   .company-detail-panel .company-title {
     color: #000000 !important; /* black company name */
   }
-  
+
   /* Reduce spacing between section titles and content like CMF */
   .company-detail-panel .mb-3 {
     margin-bottom: 0.25rem !important; /* tight title spacing like CMF */
   }
-  
+
   /* Increase space between sections for better separation like CMF */
   .company-detail-panel .space-y-6 > * + * {
     margin-top: 1rem !important; /* match CMF section spacing */
   }
-  
+
   /* Make match reasons and bullet points more compact like CMF */
   .company-detail-panel .space-y-2 > * + * {
     margin-top: 0.25rem !important; /* tighter spacing like CMF bullets */
   }
-  
+
   /* Compact related companies section like company list */
   .company-detail-panel .bg-gray-50.p-3 {
     padding: 0.375rem !important; /* match company list compactness */
     margin-bottom: 0.25rem !important;
   }
-  
+
   /* Make the main confidence indicator emphasized with bold text */
   .company-detail-panel span.text-lg.font-bold.px-3.py-1.rounded-full.text-white {
     font-size: 0.75rem !important; /* text-xs size like small badges */
     font-weight: 700 !important; /* font-bold for emphasis */
     padding: 0.375rem 0.5rem !important; /* match the updated badge padding */
   }
-  
+
   /* Make progress bar slightly thinner */
   .company-detail-panel .h-2 {
     height: 0.375rem !important; /* thinner progress bar */


### PR DESCRIPTION
## Summary
- Fixes toast positioning to be centered horizontally on the screen
- Aligns toast notifications directly under the Explore/Watchlist tabs

## Changes
- Updated Sonner toast CSS positioning from `left: 25%` to `left: 50%`
- Updated comment to reflect that tabs are centered at 50% of viewport

## Problem
The toast notifications were positioned at 25% from the left edge, which didn't align with the centered Explore/Watchlist tabs (positioned at 50% with `left-1/2 transform -translate-x-1/2`).

## Solution
Changed the toast container positioning to match the tab centering at 50% viewport width, ensuring visual consistency.

## Testing
- Manually tested by triggering toast notifications (add company, toggle watchlist)
- Verified toast appears centered under the tabs

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)