### PR TITLE
fix: Center toast notifications under Explore/Watchlist tabs

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -189,9 +189,9 @@ span.rounded-full.text-white[style*="background"] {
 }
 
 /* Sonner toast positioning - center horizontally to match Explore/Watchlist tabs */
-/* Tabs are centered in the left graph container (flex-1), so position at 25% of viewport */
+/* Tabs use left-1/2 transform -translate-x-1/2 for centering at 50% viewport width */
 [data-sonner-toaster][data-position="top-center"] {
-  left: 25% !important;
+  left: 50% !important;
   transform: translateX(-50%) !important;
 }
 


### PR DESCRIPTION
## Issue
Closes #37

## Problem
The toast notifications were positioned at 25% from the left edge, which didn't align with the centered Explore/Watchlist tabs.

## Root Cause
The Explore/Watchlist tabs are centered using `left-1/2 transform -translate-x-1/2` (positioning at 50% of viewport width), but the Sonner toast container was positioned at 25%, causing misalignment.

## Solution
Updated the Sonner toast CSS positioning from 25% to 50% viewport width to match the tab centering.

## Changes
- **File**: `src/styles/index.css`
- **Change**: Updated `[data-sonner-toaster][data-position="top-center"]` left position from 25% to 50%
- **Comment**: Updated inline documentation to clarify the tab centering mechanism

## Testing
- All pre-commit checks passed (ESLint, TypeScript, Unit Tests, Build)
- Manual testing shows toast notifications now appear centered under the Explore/Watchlist tabs
- No breaking changes - CSS-only update

## Trade-offs
None - this is a straightforward bug fix with no functional impact.