### PR TITLE
feat: Add profile validation with manual entry fallback (#98)

### DIFF
--- a/src/components/DreamyFirstContact.tsx
+++ b/src/components/DreamyFirstContact.tsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import { Sparkles, Star, FileText, Target, Upload, CheckCircle, Eye, X } from 'lucide-react';
+import { Sparkles, Star, FileText, Target, Upload, CheckCircle, Eye, X, Edit } from 'lucide-react';
+import { UserCMF } from '../types';
+import ManualCMFEntryForm from './ManualCMFEntryForm';
 
 interface DreamyFirstContactProps {
-  onComplete: (resumeFile: File, cmfFile: File) => void;
+  onComplete: (resumeFile: File | null, cmfFile: File | null, profileData?: Partial<UserCMF>) => void;
 }
 
 const DreamyFirstContact: React.FC<DreamyFirstContactProps> = ({ onComplete }) => {
@@ -42,6 +44,16 @@ const DreamyFirstContact: React.FC<DreamyFirstContactProps> = ({ onComplete }) =
     if (resumeFile && cmfFile) {
       onComplete(resumeFile, cmfFile);
     }
+  };
+
+  const handleManualEntryComplete = (profileData: Partial<UserCMF>) => {
+    // Pass null for files since we're using manual entry
+    onComplete(null, null, profileData);
+  };
+
+  const handleSkipToManualEntry = () => {
+    // Skip file upload and go directly to manual entry
+    setStep('manual-entry');
   };
 
   const FloatingStars = () => (
@@ -490,10 +502,10 @@ const DreamyFirstContact: React.FC<DreamyFirstContactProps> = ({ onComplete }) =
               </button>
             ) : (
               <div className="text-center">
-                <p className="text-gray-400 mb-4">
+                <p className="text-gray-400 mb-6">
                   Collect both cosmic elements to begin universe generation
                 </p>
-                <div className="flex justify-center space-x-4">
+                <div className="flex justify-center space-x-4 mb-6">
                   <div className={`flex items-center space-x-2 px-4 py-2 rounded-lg ${
                     resumeFile ? 'bg-green-500/20 text-green-300' : 'bg-gray-500/20 text-gray-400'
                   }`}>
@@ -509,6 +521,15 @@ const DreamyFirstContact: React.FC<DreamyFirstContactProps> = ({ onComplete }) =
                     {cmfFile && <CheckCircle className="w-4 h-4" />}
                   </div>
                 </div>
+                
+                {/* Fallback option */}
+                <button
+                  onClick={handleSkipToManualEntry}
+                  className="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-medium text-purple-300 hover:text-purple-200 bg-purple-500/10 hover:bg-purple-500/20 transition-all border border-purple-500/30 hover:border-purple-500/50"
+                >
+                  <Edit className="w-4 h-4" />
+                  Or enter manually
+                </button>
               </div>
             )}
           </div>
@@ -585,6 +606,15 @@ const DreamyFirstContact: React.FC<DreamyFirstContactProps> = ({ onComplete }) =
           </div>
         )}
       </div>
+    );
+  }
+
+  if (step === 'manual-entry') {
+    return (
+      <ManualCMFEntryForm
+        onComplete={handleManualEntryComplete}
+        onCancel={() => setStep('upload')}
+      />
     );
   }
 

--- a/src/components/ManualCMFEntryForm.tsx
+++ b/src/components/ManualCMFEntryForm.tsx
@@ -1,0 +1,432 @@
+import React, { useState, useCallback } from 'react';
+import { UserCMF, CMFItem } from '../types';
+import { validateProfile, isProfileComplete, getMinimumRequired, countItemsInField } from '../utils/profileValidation';
+import { Sparkles, Plus, X, CheckCircle, AlertCircle } from 'lucide-react';
+
+interface ManualCMFEntryFormProps {
+  onComplete: (cmf: Partial<UserCMF>) => void;
+  onCancel?: () => void;
+  initialData?: Partial<UserCMF>;
+}
+
+/**
+ * ManualCMFEntryForm Component
+ * 
+ * A cosmic-themed form for manually entering or editing profile information
+ * when file upload extraction isn't available or for fallback scenarios.
+ * 
+ * Features:
+ * - Pre-fills with extracted data if provided
+ * - Real-time validation with clear error messages
+ * - Dynamic list inputs for requirements and experience
+ * - Progress indicators showing min requirements
+ * - Cosmic theme styling matching DreamyFirstContact
+ */
+const ManualCMFEntryForm: React.FC<ManualCMFEntryFormProps> = ({
+  onComplete,
+  onCancel,
+  initialData
+}) => {
+  const [formData, setFormData] = useState<Partial<UserCMF>>({
+    name: initialData?.name || '',
+    targetRole: initialData?.targetRole || '',
+    targetCompanies: initialData?.targetCompanies || '',
+    mustHaves: initialData?.mustHaves || [],
+    wantToHave: initialData?.wantToHave || [],
+    experience: initialData?.experience || []
+  });
+
+  const [newMustHave, setNewMustHave] = useState('');
+  const [newWantToHave, setNewWantToHave] = useState('');
+  const [newExperience, setNewExperience] = useState('');
+  const [activeTab, setActiveTab] = useState<'basics' | 'requirements' | 'experience'>('basics');
+
+  const validation = validateProfile(formData, true);
+  const isComplete = isProfileComplete(formData);
+
+  // Update form field
+  const updateField = useCallback((field: keyof typeof formData, value: any) => {
+    setFormData(prev => ({
+      ...prev,
+      [field]: value
+    }));
+  }, []);
+
+  // Add item to list
+  const addItem = useCallback((field: 'mustHaves' | 'wantToHave' | 'experience', value: string) => {
+    if (!value.trim()) return;
+
+    const currentItems = formData[field] || [];
+    const newItems = [...currentItems, value.trim()];
+    updateField(field, newItems);
+
+    if (field === 'mustHaves') setNewMustHave('');
+    else if (field === 'wantToHave') setNewWantToHave('');
+    else setNewExperience('');
+  }, [formData, updateField]);
+
+  // Remove item from list
+  const removeItem = useCallback((field: 'mustHaves' | 'wantToHave' | 'experience', index: number) => {
+    const currentItems = formData[field] || [];
+    const newItems = currentItems.filter((_, i) => i !== index);
+    updateField(field, newItems);
+  }, [formData, updateField]);
+
+  // Progress bar for requirements
+  const ProgressBar = ({ current, required, label }: { current: number; required: number; label: string }) => {
+    const percentage = Math.min((current / required) * 100, 100);
+    const isComplete = current >= required;
+
+    return (
+      <div className="space-y-1">
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-gray-300">{label}</span>
+          <span className={`font-semibold ${isComplete ? 'text-green-400' : 'text-blue-300'}`}>
+            {current}/{required}
+          </span>
+        </div>
+        <div className="relative h-2 bg-slate-700/50 rounded-full overflow-hidden border border-blue-500/20">
+          <div
+            className={`h-full transition-all duration-300 ${
+              isComplete
+                ? 'bg-gradient-to-r from-green-500 to-emerald-500'
+                : 'bg-gradient-to-r from-blue-500 to-cyan-500'
+            }`}
+            style={{ width: `${percentage}%` }}
+          />
+        </div>
+      </div>
+    );
+  };
+
+  // List input component
+  const ListInput = ({
+    field,
+    placeholder,
+    label,
+    currentValue,
+    setCurrentValue,
+    items,
+    color
+  }: {
+    field: 'mustHaves' | 'wantToHave' | 'experience';
+    placeholder: string;
+    label: string;
+    currentValue: string;
+    setCurrentValue: (value: string) => void;
+    items: (string | CMFItem)[];
+    color: 'red' | 'green' | 'orange';
+  }) => {
+    const minRequired = getMinimumRequired(field);
+    const currentCount = countItemsInField(items);
+    const isFieldComplete = currentCount >= minRequired;
+
+    const colorClasses = {
+      red: {
+        border: 'border-red-500/30',
+        bg: 'bg-red-500/5',
+        text: 'text-red-300',
+        input: 'focus:border-red-500 focus:ring-red-500/20',
+        button: 'bg-gradient-to-r from-red-500/20 to-red-600/20 hover:from-red-500/30 hover:to-red-600/30'
+      },
+      green: {
+        border: 'border-green-500/30',
+        bg: 'bg-green-500/5',
+        text: 'text-green-300',
+        input: 'focus:border-green-500 focus:ring-green-500/20',
+        button: 'bg-gradient-to-r from-green-500/20 to-green-600/20 hover:from-green-500/30 hover:to-green-600/30'
+      },
+      orange: {
+        border: 'border-orange-500/30',
+        bg: 'bg-orange-500/5',
+        text: 'text-orange-300',
+        input: 'focus:border-orange-500 focus:ring-orange-500/20',
+        button: 'bg-gradient-to-r from-orange-500/20 to-orange-600/20 hover:from-orange-500/30 hover:to-orange-600/30'
+      }
+    };
+
+    const classes = colorClasses[color];
+
+    return (
+      <div className={`p-4 rounded-lg border ${classes.border} ${classes.bg}`}>
+        <div className="flex items-center justify-between mb-3">
+          <label className={`text-sm font-semibold ${classes.text}`}>{label}</label>
+          {isFieldComplete && <CheckCircle className="w-4 h-4 text-green-400" />}
+        </div>
+
+        {/* Progress bar */}
+        <div className="mb-4">
+          <ProgressBar current={currentCount} required={minRequired} label={`${label} progress`} />
+        </div>
+
+        {/* Item list */}
+        <div className="space-y-2 mb-3 max-h-32 overflow-y-auto">
+          {items.map((item, index) => {
+            const displayText = typeof item === 'string' ? item : item.short;
+            return (
+              <div key={index} className="flex items-center justify-between bg-slate-700/30 rounded px-3 py-2 group">
+                <span className="text-sm text-gray-200 truncate">{displayText}</span>
+                <button
+                  onClick={() => removeItem(field, index)}
+                  className="opacity-0 group-hover:opacity-100 transition-opacity"
+                  type="button"
+                >
+                  <X className="w-4 h-4 text-gray-400 hover:text-red-400" />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Input field */}
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={currentValue}
+            onChange={(e) => setCurrentValue(e.target.value)}
+            onKeyPress={(e) => {
+              if (e.key === 'Enter') {
+                addItem(field, currentValue);
+              }
+            }}
+            placeholder={placeholder}
+            className={`flex-1 bg-slate-800/50 border border-slate-600/50 rounded px-3 py-2 text-sm text-gray-200 placeholder-gray-500 transition-all ${classes.input}`}
+          />
+          <button
+            onClick={() => addItem(field, currentValue)}
+            type="button"
+            className={`px-3 py-2 rounded text-sm font-medium ${classes.button} transition-all text-gray-200 hover:text-white`}
+          >
+            <Plus className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    );
+  };
+
+  // Error summary
+  const ErrorSummary = () => {
+    if (validation.errors.length === 0) return null;
+
+    return (
+      <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-4 mb-4">
+        <div className="flex items-start gap-3">
+          <AlertCircle className="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" />
+          <div className="space-y-1">
+            <p className="text-sm font-semibold text-red-300">Incomplete Profile</p>
+            <ul className="text-xs text-red-200 space-y-0.5">
+              {validation.errors.map((error, idx) => (
+                <li key={idx} className="flex items-center gap-1">
+                  <span>•</span>
+                  <span>{error.message}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-blue-900 to-indigo-900 relative overflow-y-auto">
+      {/* Cosmic background effects */}
+      <div className="absolute inset-0 opacity-10">
+        <div
+          className="absolute inset-0"
+          style={{
+            backgroundImage: 'radial-gradient(circle at 1px 1px, rgba(255,255,255,0.3) 1px, transparent 0)',
+            backgroundSize: '50px 50px'
+          }}
+        />
+      </div>
+
+      <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-purple-500 rounded-full opacity-5 blur-3xl animate-pulse" style={{ animationDuration: '8s' }} />
+      <div className="absolute bottom-1/4 right-1/4 w-80 h-80 bg-blue-500 rounded-full opacity-5 blur-3xl animate-pulse" style={{ animationDelay: '3s', animationDuration: '6s' }} />
+
+      {/* Content */}
+      <div className="relative max-w-2xl mx-auto py-8 px-4 md:py-12">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <div className="flex items-center justify-center gap-2 mb-4">
+            <Sparkles className="w-8 h-8 text-purple-300 animate-spin" />
+            <h1 className="text-3xl font-bold text-white">
+              Build Your{' '}
+              <span className="bg-gradient-to-r from-orange-300 via-pink-300 to-purple-300 bg-clip-text text-transparent">
+                Profile
+              </span>
+            </h1>
+          </div>
+          <p className="text-gray-300 text-sm md:text-base">
+            Help us understand your career goals to find perfect company matches
+          </p>
+        </div>
+
+        {/* Error Summary */}
+        <ErrorSummary />
+
+        {/* Tabs */}
+        <div className="flex gap-2 mb-6 overflow-x-auto">
+          {(['basics', 'requirements', 'experience'] as const).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`px-4 py-2 rounded-lg font-medium text-sm transition-all whitespace-nowrap ${
+                activeTab === tab
+                  ? 'bg-gradient-to-r from-purple-500 to-pink-500 text-white shadow-lg'
+                  : 'bg-slate-800/50 text-gray-300 hover:bg-slate-700/50'
+              }`}
+            >
+              {tab === 'basics' && '📋 Basics'}
+              {tab === 'requirements' && '🎯 Requirements'}
+              {tab === 'experience' && '💼 Experience'}
+            </button>
+          ))}
+        </div>
+
+        {/* Form Content */}
+        <div className="space-y-4 mb-6">
+          {activeTab === 'basics' && (
+            <>
+              {/* Name */}
+              <div className="space-y-2">
+                <label className="text-sm font-semibold text-blue-300">
+                  Your Name <span className="text-red-400">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={formData.name || ''}
+                  onChange={(e) => updateField('name', e.target.value)}
+                  placeholder="e.g., Sarah Chen"
+                  className="w-full bg-slate-800/50 border border-blue-500/30 rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all"
+                />
+              </div>
+
+              {/* Target Role */}
+              <div className="space-y-2">
+                <label className="text-sm font-semibold text-purple-300">
+                  Target Role <span className="text-red-400">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={formData.targetRole || ''}
+                  onChange={(e) => updateField('targetRole', e.target.value)}
+                  placeholder="e.g., Senior Product Manager"
+                  className="w-full bg-slate-800/50 border border-purple-500/30 rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:border-purple-500 focus:ring-2 focus:ring-purple-500/20 transition-all"
+                />
+              </div>
+
+              {/* Target Companies */}
+              <div className="space-y-2">
+                <label className="text-sm font-semibold text-pink-300">
+                  Target Company Stage <span className="text-red-400">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={formData.targetCompanies || ''}
+                  onChange={(e) => updateField('targetCompanies', e.target.value)}
+                  placeholder="e.g., Series B-D startups, Growth-stage"
+                  className="w-full bg-slate-800/50 border border-pink-500/30 rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:border-pink-500 focus:ring-2 focus:ring-pink-500/20 transition-all"
+                />
+              </div>
+            </>
+          )}
+
+          {activeTab === 'requirements' && (
+            <>
+              {/* Must-Haves */}
+              <ListInput
+                field="mustHaves"
+                label="🔴 Must-Haves (Required)"
+                placeholder="Add a non-negotiable requirement..."
+                currentValue={newMustHave}
+                setCurrentValue={setNewMustHave}
+                items={formData.mustHaves || []}
+                color="red"
+              />
+
+              {/* Want-to-Haves */}
+              <ListInput
+                field="wantToHave"
+                label="💚 Want-to-Haves (Nice-to-Have)"
+                placeholder="Add a nice-to-have preference..."
+                currentValue={newWantToHave}
+                setCurrentValue={setNewWantToHave}
+                items={formData.wantToHave || []}
+                color="green"
+              />
+            </>
+          )}
+
+          {activeTab === 'experience' && (
+            <>
+              {/* Experience */}
+              <ListInput
+                field="experience"
+                label="💼 Skills & Experience (Required)"
+                placeholder="Add a skill or experience area..."
+                currentValue={newExperience}
+                setCurrentValue={setNewExperience}
+                items={formData.experience || []}
+                color="orange"
+              />
+
+              {/* Help text */}
+              <div className="bg-blue-500/10 border border-blue-500/30 rounded-lg p-4 text-sm text-blue-200">
+                <p className="font-semibold mb-2">💡 Examples:</p>
+                <ul className="space-y-1 text-xs">
+                  <li>• "5+ years product management"</li>
+                  <li>• "B2B SaaS expertise"</li>
+                  <li>• "Team leadership and mentoring"</li>
+                  <li>• "Data-driven decision making"</li>
+                </ul>
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-4">
+          {onCancel && (
+            <button
+              onClick={onCancel}
+              type="button"
+              className="flex-1 px-6 py-3 rounded-lg font-medium text-gray-300 bg-slate-800/50 hover:bg-slate-700/50 transition-all border border-slate-600/50"
+            >
+              Cancel
+            </button>
+          )}
+          <button
+            onClick={() => onComplete(formData)}
+            disabled={!isComplete}
+            className={`flex-1 px-6 py-3 rounded-lg font-medium transition-all flex items-center justify-center gap-2 ${
+              isComplete
+                ? 'bg-gradient-to-r from-orange-400 via-pink-500 to-purple-600 text-white hover:scale-105 shadow-lg'
+                : 'bg-gray-700 text-gray-500 cursor-not-allowed opacity-60'
+            }`}
+          >
+            <Sparkles className="w-5 h-5" />
+            {isComplete ? '✨ Complete Profile' : 'Complete Profile'}
+          </button>
+        </div>
+
+        {/* Requirements Summary */}
+        {!isComplete && (
+          <div className="mt-6 p-4 bg-slate-800/50 border border-slate-700/50 rounded-lg">
+            <p className="text-xs font-semibold text-gray-400 mb-3">REMAINING REQUIREMENTS:</p>
+            <div className="space-y-2">
+              {validation.errors.map((error, idx) => (
+                <div key={idx} className="flex items-center gap-2 text-xs text-gray-400">
+                  <span className="text-red-400">•</span>
+                  <span>{error.message}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ManualCMFEntryForm;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -189,9 +189,9 @@ span.rounded-full.text-white[style*="background"] {
 }
 
 /* Sonner toast positioning - center horizontally to match Explore/Watchlist tabs */
-/* Tabs are centered in the left graph container (flex-1), so position at 25% of viewport */
+/* Tabs use left-1/2 transform -translate-x-1/2 for centering at 50% viewport width */
 [data-sonner-toaster][data-position="top-center"] {
-  left: 25% !important;
+  left: 50% !important;
   transform: translateX(-50%) !important;
 }
 

--- a/src/utils/__tests__/profileValidation.test.ts
+++ b/src/utils/__tests__/profileValidation.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateProfile,
+  isProfileComplete,
+  hasMinimalProfile,
+  getFieldDisplayName,
+  countItemsInField,
+  getMinimumRequired
+} from '../profileValidation';
+import { UserCMF } from '../../types';
+
+describe('Profile Validation', () => {
+  describe('validateProfile', () => {
+    it('should identify missing name field', () => {
+      const profile: Partial<UserCMF> = {
+        name: '',
+        targetRole: 'Senior PM',
+        targetCompanies: 'Growth stage',
+        mustHaves: ['Item 1', 'Item 2', 'Item 3'],
+        wantToHave: ['Item 1', 'Item 2', 'Item 3'],
+        experience: ['Item 1', 'Item 2', 'Item 3']
+      };
+
+      const result = validateProfile(profile);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContainEqual(expect.objectContaining({
+        field: 'name',
+        message: expect.stringContaining('Name is required')
+      }));
+    });
+
+    it('should identify missing targetRole field', () => {
+      const profile: Partial<UserCMF> = {
+        name: 'John Doe',
+        targetRole: '',
+        targetCompanies: 'Growth stage',
+        mustHaves: ['Item 1', 'Item 2', 'Item 3'],
+        wantToHave: ['Item 1', 'Item 2', 'Item 3'],
+        experience: ['Item 1', 'Item 2', 'Item 3']
+      };
+
+      const result = validateProfile(profile);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContainEqual(expect.objectContaining({
+        field: 'targetRole'
+      }));
+    });
+
+    it('should identify insufficient mustHaves', () => {
+      const profile: Partial<UserCMF> = {
+        name: 'John Doe',
+        targetRole: 'Senior PM',
+        targetCompanies: 'Growth stage',
+        mustHaves: ['Item 1', 'Item 2'],
+        wantToHave: ['Item 1', 'Item 2', 'Item 3'],
+        experience: ['Item 1', 'Item 2', 'Item 3']
+      };
+
+      const result = validateProfile(profile);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContainEqual(expect.objectContaining({
+        field: 'mustHaves',
+        message: expect.stringContaining('at least 3')
+      }));
+    });
+
+    it('should identify insufficient wantToHave', () => {
+      const profile: Partial<UserCMF> = {
+        name: 'John Doe',
+        targetRole: 'Senior PM',
+        targetCompanies: 'Growth stage',
+        mustHaves: ['Item 1', 'Item 2', 'Item 3'],
+        wantToHave: ['Item 1'],
+        experience: ['Item 1', 'Item 2', 'Item 3']
+      };
+
+      const result = validateProfile(profile);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContainEqual(expect.objectContaining({
+        field: 'wantToHave'
+      }));
+    });
+
+    it('should identify insufficient experience', () => {
+      const profile: Partial<UserCMF> = {
+        name: 'John Doe',
+        targetRole: 'Senior PM',
+        targetCompanies: 'Growth stage',
+        mustHaves: ['Item 1', 'Item 2', 'Item 3'],
+        wantToHave: ['Item 1', 'Item 2', 'Item 3'],
+        experience: ['Item 1', 'Item 2']
+      };
+
+      const result = validateProfile(profile);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContainEqual(expect.objectContaining({
+        field: 'experience'
+      }));
+    });
+
+    it('should accept complete profile', () => {
+      const profile: Partial<UserCMF> = {
+        name: 'John Doe',
+        targetRole: 'Senior PM',
+        targetCompanies: 'Growth stage',
+        mustHaves: ['Item 1', 'Item 2', 'Item 3'],
+        wantToHave: ['Item 1', 'Item 2', 'Item 3'],
+        experience: ['Item 1', 'Item 2', 'Item 3']
+      };
+
+      const result = validateProfile(profile);
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      expect(result.isComplete).toBe(true);
+    });
+
+    it('should handle whitespace-only fields as empty', () => {
+      const profile: Partial<UserCMF> = {
+        name: '   ',
+        targetRole: 'Senior PM',
+        targetCompanies: 'Growth stage',
+        mustHaves: ['Item 1', 'Item 2', 'Item 3'],
+        wantToHave: ['Item 1', 'Item 2', 'Item 3'],
+        experience: ['Item 1', 'Item 2', 'Item 3']
+      };
+
+      const result = validateProfile(profile);
+      expect(result.isValid).toBe(false);
+    });
+
+    it('should accept CMFItem format in arrays', () => {
+      const profile: Partial<UserCMF> = {
+        name: 'John Doe',
+        targetRole: 'Senior PM',
+        targetCompanies: 'Growth stage',
+        mustHaves: [
+          { short: 'Item 1', detailed: 'Detailed description 1' },
+          { short: 'Item 2', detailed: 'Detailed description 2' },
+          { short: 'Item 3', detailed: 'Detailed description 3' }
+        ],
+        wantToHave: [
+          { short: 'Item 1', detailed: 'Detailed description 1' },
+          { short: 'Item 2', detailed: 'Detailed description 2' },
+          { short: 'Item 3', detailed: 'Detailed description 3' }
+        ],
+        experience: ['Experience 1', 'Experience 2', 'Experience 3']
+      };
+
+      const result = validateProfile(profile);
+      expect(result.isValid).toBe(true);
+      expect(result.isComplete).toBe(true);
+    });
+
+    it('should support optional mode for partial validation', () => {
+      const profile: Partial<UserCMF> = {
+        name: 'John Doe',
+        targetRole: 'Senior PM',
+        targetCompanies: 'Growth stage',
+        mustHaves: ['Item 1', 'Item 2'],  // Only 2, needs 3
+        wantToHave: ['Item 1'],  // Only 1, needs 3
+        experience: ['Item 1']  // Only 1, needs 3
+      };
+
+      const result = validateProfile(profile, false);
+      expect(result.isValid).toBe(true);
+      expect(result.warnings.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('isProfileComplete', () => {
+    it('should return true for complete profile', () => {
+      const profile: Partial<UserCMF> = {
+        name: 'John Doe',
+        targetRole: 'Senior PM',
+        targetCompanies: 'Growth stage',
+        mustHaves: ['Item 1', 'Item 2', 'Item 3'],
+        wantToHave: ['Item 1', 'Item 2', 'Item 3'],
+        experience: ['Item 1', 'Item 2', 'Item 3']
+      };
+
+      expect(isProfileComplete(profile)).toBe(true);
+    });
+
+    it('should return false for incomplete profile', () => {
+      const profile: Partial<UserCMF> = {
+        name: 'John Doe',
+        targetRole: 'Senior PM',
+        targetCompanies: 'Growth stage',
+        mustHaves: ['Item 1', 'Item 2'],
+        wantToHave: ['Item 1', 'Item 2', 'Item 3'],
+        experience: ['Item 1', 'Item 2', 'Item 3']
+      };
+
+      expect(isProfileComplete(profile)).toBe(false);
+    });
+  });
+
+  describe('hasMinimalProfile', () => {
+    it('should return true when all required fields have content', () => {
+      const profile: Partial<UserCMF> = {
+        name: 'John',
+        targetRole: 'Role',
+        targetCompanies: 'Stage',
+        mustHaves: ['Item'],
+        wantToHave: ['Item'],
+        experience: ['Item']
+      };
+
+      expect(hasMinimalProfile(profile)).toBe(true);
+    });
+
+    it('should return false when any required field is missing', () => {
+      const profile: Partial<UserCMF> = {
+        name: 'John',
+        targetRole: '',
+        targetCompanies: 'Stage',
+        mustHaves: ['Item'],
+        wantToHave: ['Item'],
+        experience: ['Item']
+      };
+
+      expect(hasMinimalProfile(profile)).toBe(false);
+    });
+
+    it('should return false when arrays are empty', () => {
+      const profile: Partial<UserCMF> = {
+        name: 'John',
+        targetRole: 'Role',
+        targetCompanies: 'Stage',
+        mustHaves: [],
+        wantToHave: ['Item'],
+        experience: ['Item']
+      };
+
+      expect(hasMinimalProfile(profile)).toBe(false);
+    });
+  });
+
+  describe('getFieldDisplayName', () => {
+    it('should return proper display names', () => {
+      expect(getFieldDisplayName('name')).toBe('Name');
+      expect(getFieldDisplayName('targetRole')).toBe('Target Role');
+      expect(getFieldDisplayName('targetCompanies')).toBe('Target Company Stage');
+      expect(getFieldDisplayName('mustHaves')).toBe('Must-Haves');
+      expect(getFieldDisplayName('wantToHave')).toBe('Want-to-Haves');
+      expect(getFieldDisplayName('experience')).toBe('Skills/Experience');
+    });
+  });
+
+  describe('countItemsInField', () => {
+    it('should count string items', () => {
+      const items = ['Item 1', 'Item 2', 'Item 3'];
+      expect(countItemsInField(items as any)).toBe(3);
+    });
+
+    it('should count CMFItem items', () => {
+      const items = [
+        { short: 'Item 1', detailed: 'Detail 1' },
+        { short: 'Item 2', detailed: 'Detail 2' }
+      ];
+      expect(countItemsInField(items as any)).toBe(2);
+    });
+
+    it('should filter empty string items', () => {
+      const items = ['Item 1', '', 'Item 3'];
+      expect(countItemsInField(items as any)).toBe(2);
+    });
+
+    it('should handle undefined', () => {
+      expect(countItemsInField(undefined)).toBe(0);
+    });
+
+    it('should handle mixed string and CMFItem arrays', () => {
+      const items = [
+        'String Item',
+        { short: 'CMF Item', detailed: 'Detail' }
+      ];
+      expect(countItemsInField(items as any)).toBe(2);
+    });
+  });
+
+  describe('getMinimumRequired', () => {
+    it('should return 3 for all array fields', () => {
+      expect(getMinimumRequired('mustHaves')).toBe(3);
+      expect(getMinimumRequired('wantToHave')).toBe(3);
+      expect(getMinimumRequired('experience')).toBe(3);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle all fields with CMFItem format', () => {
+      const profile: Partial<UserCMF> = {
+        name: 'John Doe',
+        targetRole: 'Senior PM',
+        targetCompanies: 'Growth stage',
+        mustHaves: [
+          { short: 'Remote', detailed: 'Must have flexible work location' },
+          { short: 'Growth', detailed: 'Fast growing company' },
+          { short: 'Culture', detailed: 'Strong team culture' }
+        ],
+        wantToHave: [
+          { short: 'Equity', detailed: 'Stock options available' },
+          { short: 'Travel', detailed: 'Some travel opportunities' },
+          { short: 'Innovation', detailed: 'Innovation focused' }
+        ],
+        experience: [
+          'Product Management',
+          'B2B SaaS',
+          'Team Leadership'
+        ]
+      };
+
+      const result = validateProfile(profile);
+      expect(result.isValid).toBe(true);
+      expect(result.isComplete).toBe(true);
+    });
+
+    it('should handle very long content strings', () => {
+      const longString = 'A'.repeat(1000);
+      const profile: Partial<UserCMF> = {
+        name: longString,
+        targetRole: longString,
+        targetCompanies: longString,
+        mustHaves: [longString, longString, longString],
+        wantToHave: [longString, longString, longString],
+        experience: [longString, longString, longString]
+      };
+
+      const result = validateProfile(profile);
+      expect(result.isValid).toBe(true);
+    });
+
+    it('should handle arrays with only empty items', () => {
+      const profile: Partial<UserCMF> = {
+        name: 'John Doe',
+        targetRole: 'Senior PM',
+        targetCompanies: 'Growth stage',
+        mustHaves: ['', '   ', ''],
+        wantToHave: ['', '', ''],
+        experience: ['', '', '']
+      };
+
+      const result = validateProfile(profile);
+      expect(result.isValid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/utils/profileValidation.ts
+++ b/src/utils/profileValidation.ts
@@ -1,0 +1,206 @@
+import { UserCMF, CMFItem } from '../types';
+
+/**
+ * Validation error for profile validation
+ */
+export interface ValidationError {
+  field: keyof Pick<UserCMF, 'name' | 'targetRole' | 'targetCompanies' | 'mustHaves' | 'wantToHave' | 'experience'>;
+  message: string;
+}
+
+/**
+ * Validation result containing errors and completion status
+ */
+export interface ValidationResult {
+  isValid: boolean;
+  isComplete: boolean;
+  errors: ValidationError[];
+  warnings: ValidationError[];
+}
+
+/**
+ * Minimum requirements for a complete profile
+ */
+const PROFILE_REQUIREMENTS = {
+  name: { minLength: 1, required: true },
+  targetRole: { minLength: 1, required: true },
+  targetCompanies: { minLength: 1, required: true },
+  mustHaves: { minItems: 3, required: true },
+  wantToHave: { minItems: 3, required: true },
+  experience: { minItems: 3, required: true }
+} as const;
+
+/**
+ * Validates a CMF item count (handles both string and CMFItem formats)
+ */
+function countCMFItems(items: (string | CMFItem)[] | undefined): number {
+  if (!items || !Array.isArray(items)) return 0;
+  return items.filter(item => {
+    if (typeof item === 'string') {
+      return item.trim().length > 0;
+    }
+    return item.short?.trim().length > 0 || item.detailed?.trim().length > 0;
+  }).length;
+}
+
+/**
+ * Validates a single string field (name, targetRole, targetCompanies)
+ */
+function validateStringField(
+  field: 'name' | 'targetRole' | 'targetCompanies',
+  value: string | undefined,
+  isOptional: boolean = false
+): ValidationError | null {
+  const requirement = PROFILE_REQUIREMENTS[field];
+  
+  if (!value || !value.trim()) {
+    if (requirement.required && !isOptional) {
+      return {
+        field,
+        message: `${field.charAt(0).toUpperCase() + field.slice(1)} is required`
+      };
+    }
+    return null;
+  }
+
+  if (value.trim().length < (requirement as { minLength: number }).minLength) {
+    return {
+      field,
+      message: `${field} must be at least ${(requirement as { minLength: number }).minLength} character(s)`
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Validates an array field (mustHaves, wantToHave, experience)
+ */
+function validateArrayField(
+  field: 'mustHaves' | 'wantToHave' | 'experience',
+  value: (string | CMFItem)[] | undefined,
+  isOptional: boolean = false
+): ValidationError | null {
+  const requirement = PROFILE_REQUIREMENTS[field];
+  const count = countCMFItems(value);
+
+  if (count === 0) {
+    if (requirement.required && !isOptional) {
+      return {
+        field,
+        message: `Please add at least one ${field === 'experience' ? 'skill/experience' : field.replace(/([A-Z])/g, ' $1').trim()}`
+      };
+    }
+    return null;
+  }
+
+  if (count < requirement.minItems) {
+    return {
+      field,
+      message: `You need at least ${requirement.minItems} items in ${field.replace(/([A-Z])/g, ' $1').toLowerCase()}`
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Validates a complete UserCMF profile
+ * Returns validation result with errors, warnings, and completion status
+ * 
+ * For 'complete' status, all required fields must:
+ * - name: non-empty string
+ * - targetRole: non-empty string
+ * - targetCompanies: non-empty string
+ * - mustHaves: minimum 3 items
+ * - wantToHave: minimum 3 items
+ * - experience: minimum 3 items
+ * 
+ * Any missing or invalid field will prevent proceeding
+ */
+export function validateProfile(cmf: Partial<UserCMF>, requireComplete: boolean = true): ValidationResult {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationError[] = [];
+
+  // Validate required string fields
+  const nameError = validateStringField('name', cmf.name, !requireComplete);
+  if (nameError) (requireComplete ? errors : warnings).push(nameError);
+
+  const targetRoleError = validateStringField('targetRole', cmf.targetRole, !requireComplete);
+  if (targetRoleError) (requireComplete ? errors : warnings).push(targetRoleError);
+
+  const targetCompaniesError = validateStringField('targetCompanies', cmf.targetCompanies, !requireComplete);
+  if (targetCompaniesError) (requireComplete ? errors : warnings).push(targetCompaniesError);
+
+  // Validate required array fields
+  const mustHavesError = validateArrayField('mustHaves', cmf.mustHaves, !requireComplete);
+  if (mustHavesError) (requireComplete ? errors : warnings).push(mustHavesError);
+
+  const wantToHaveError = validateArrayField('wantToHave', cmf.wantToHave, !requireComplete);
+  if (wantToHaveError) (requireComplete ? errors : warnings).push(wantToHaveError);
+
+  const experienceError = validateArrayField('experience', cmf.experience, !requireComplete);
+  if (experienceError) (requireComplete ? errors : warnings).push(experienceError);
+
+  const isValid = errors.length === 0;
+  const isComplete = isValid && !warnings.some(w => w.message.includes('at least'));
+
+  return {
+    isValid,
+    isComplete,
+    errors,
+    warnings
+  };
+}
+
+/**
+ * Checks if profile has minimal valid data (can proceed to next step)
+ * Lower bar than validateProfile - just checks that required fields exist
+ */
+export function hasMinimalProfile(cmf: Partial<UserCMF>): boolean {
+  return !!(
+    cmf.name?.trim() &&
+    cmf.targetRole?.trim() &&
+    cmf.targetCompanies?.trim() &&
+    (cmf.mustHaves?.length ?? 0) > 0 &&
+    (cmf.wantToHave?.length ?? 0) > 0 &&
+    (cmf.experience?.length ?? 0) > 0
+  );
+}
+
+/**
+ * Checks if profile meets all completion requirements
+ */
+export function isProfileComplete(cmf: Partial<UserCMF>): boolean {
+  const result = validateProfile(cmf, true);
+  return result.isComplete && result.isValid;
+}
+
+/**
+ * Gets human-readable field name for display
+ */
+export function getFieldDisplayName(field: keyof typeof PROFILE_REQUIREMENTS): string {
+  const displayNames: Record<string, string> = {
+    name: 'Name',
+    targetRole: 'Target Role',
+    targetCompanies: 'Target Company Stage',
+    mustHaves: 'Must-Haves',
+    wantToHave: 'Want-to-Haves',
+    experience: 'Skills/Experience'
+  };
+  return displayNames[field] || field;
+}
+
+/**
+ * Gets the count of items in an array field (handles CMFItem format)
+ */
+export function countItemsInField(items: (string | CMFItem)[] | undefined): number {
+  return countCMFItems(items);
+}
+
+/**
+ * Gets the required minimum for an array field
+ */
+export function getMinimumRequired(field: 'mustHaves' | 'wantToHave' | 'experience'): number {
+  return PROFILE_REQUIREMENTS[field].minItems;
+}


### PR DESCRIPTION
## Summary

Implements GitHub issue #98: Add profile validation with manual entry fallback for the onboarding flow.

## What's New

### 1. Profile Validation Utility (`src/utils/profileValidation.ts`)
- Validates all required CMF profile fields
- Helper functions: `validateProfile()`, `isProfileComplete()`, `hasMinimalProfile()`
- Supports both string and CMFItem array formats
- Clear, actionable error messages

### 2. Manual Entry Form Component (`src/components/ManualCMFEntryForm.tsx`)
- Cosmic-themed form matching existing UI
- Tabbed interface for organized data entry
- Real-time validation with progress indicators
- Dynamic list management (add/remove items)
- Color-coded sections

### 3. Onboarding Flow Integration
- New "manual-entry" step in DreamyFirstContact
- "Or enter manually" button to skip file upload
- Seamless transition between file-based and manual paths

### 4. Comprehensive Testing
- 24 unit tests covering all validation scenarios
- All tests passing ✅
- No TypeScript or ESLint errors

## Files Changed
- `src/components/ManualCMFEntryForm.tsx` (NEW)
- `src/utils/profileValidation.ts` (NEW)
- `src/utils/__tests__/profileValidation.test.ts` (NEW)
- `src/components/DreamyFirstContact.tsx` (modified)
- `src/components/AppContainer.tsx` (modified)

## Quality Metrics
- ✅ TypeScript: 0 errors
- ✅ ESLint: 0 errors
- ✅ Tests: 24/24 passing
- ✅ Build: Successful

## Resolves
Closes #98