### PR TITLE
feat(feedback): Add company analysis correction and re-analysis

### DIFF
--- a/app/api/llm/anthropic/analyze/route.ts
+++ b/app/api/llm/anthropic/analyze/route.ts
@@ -133,7 +133,7 @@ export async function POST(request: NextRequest) {
 // Helper function to build Anthropic prompt
 function buildAnthropicPrompt(request: any) {
   return `Analyze "${request.companyName}" and provide comprehensive company information based on the user's career criteria.
-
+${request.correctionContext ? `\nIMPORTANT USER CORRECTION: The user has flagged that a previous analysis of this company was inaccurate. They clarify that this company actually does: "${request.correctionContext}". Use this correction when determining the industry and generating matchReasons — do not repeat the incorrect description.\n` : ''}
 User's Candidate Market Fit (CMF) Criteria:
 - Target Role: ${request.userCMF.targetRole}
 - Must-Haves: ${request.userCMF.mustHaves.join(', ')}

--- a/src/components/CMFGraphExplorerNew.tsx
+++ b/src/components/CMFGraphExplorerNew.tsx
@@ -484,6 +484,10 @@ const CMFGraphExplorer: React.FC<CMFGraphExplorerProps> = ({ userProfile }) => {
     return stateManager.isInWatchlist(companyId);
   }, [stateManager]);
 
+  const handleCompanyUpdate = useCallback((updatedCompany: Company) => {
+    stateManager.updateCompany(updatedCompany);
+  }, [stateManager]);
+
   // ===== COMPANY MANAGEMENT =====
 
   const handleAddCompany = useCallback(async (newCompany: Company) => {
@@ -918,6 +922,7 @@ const CMFGraphExplorer: React.FC<CMFGraphExplorerProps> = ({ userProfile }) => {
             isInWatchlist={isInWatchlist}
             onToggleWatchlist={handleToggleWatchlist}
             onRequestDelete={handleRemoveRequest}
+            onCompanyUpdate={handleCompanyUpdate}
             viewMode={viewMode}
             watchlistStats={watchlistStats}
             userCMF={stateManager.getUserCMF()}
@@ -945,6 +950,7 @@ const CMFGraphExplorer: React.FC<CMFGraphExplorerProps> = ({ userProfile }) => {
             isInWatchlist={isInWatchlist}
             onToggleWatchlist={handleToggleWatchlist}
             onRequestDelete={handleRemoveRequest}
+            onCompanyUpdate={handleCompanyUpdate}
             viewMode={viewMode}
             watchlistStats={watchlistStats}
             userCMF={stateManager.getUserCMF()}
@@ -969,6 +975,7 @@ const CMFGraphExplorer: React.FC<CMFGraphExplorerProps> = ({ userProfile }) => {
             isInWatchlist={isInWatchlist}
             onToggleWatchlist={handleToggleWatchlist}
             onRequestDelete={handleRemoveRequest}
+            onCompanyUpdate={handleCompanyUpdate}
             viewMode={viewMode}
             watchlistStats={watchlistStats}
             userCMF={stateManager.getUserCMF()}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -71,6 +71,7 @@ export interface Company {
     glassdoor?: string;
     crunchbase?: string;
   };
+  lastAnalysisRefresh?: string; // ISO timestamp — rate limits user-triggered re-analysis to once per day
 }
 
 export interface GraphData {

--- a/src/types/watchlist.ts
+++ b/src/types/watchlist.ts
@@ -61,6 +61,7 @@ export interface CompanyDetailPanelProps {
   onToggleWatchlist: (companyId: number) => void;
   onCompanySelect: (company: import('./index').Company | null) => void;
   onRequestDelete: (company: import('./index').Company) => void;
+  onCompanyUpdate?: (updatedCompany: import('./index').Company) => void;
   viewMode: ViewMode;
   watchlistStats: WatchlistStats;
   isMobile?: boolean;

--- a/src/utils/llm/types.ts
+++ b/src/utils/llm/types.ts
@@ -38,6 +38,7 @@ export interface CompanyAnalysisRequest {
     targetCompanies?: string;
   };
   isNewUser?: boolean; // Flag to indicate if user has empty CMF profile
+  correctionContext?: string; // User-provided correction when LLM description was inaccurate
 }
 
 export interface CompanyAnalysisResponse {


### PR DESCRIPTION
## Summary

- Adds an **"Incorrect info?"** link next to the "Why This Match?" heading in `CompanyDetailPanel` — only visible when a company is selected and an LLM is configured
- Clicking opens an inline amber form where the user can describe what the company actually does (optional free-text field)
- Submitting re-prompts the LLM via the existing `/api/llm/anthropic/analyze` route, injecting the user's correction as context so the LLM generates accurate `matchReasons` and `industry`
- Updated company data (matchReasons, matchScore, industry, stage, location, employees, remote, openRoles) is merged back and persisted to Supabase via the existing sync infrastructure
- **Rate-limited to once per 24 hours per company per user** via a `lastAnalysisRefresh` ISO timestamp stored on the company object — when within the cooldown, the form is replaced with a "Next refresh available in ~Xh" message

## Test plan

- [ ] Select a company in the detail panel — confirm "Incorrect info?" link appears
- [ ] Click it — confirm the amber feedback form opens with a textarea
- [ ] Submit without text — confirm re-analysis fires and match reasons update
- [ ] Submit with text (e.g. "they do LLM-based medical coding") — confirm the new reasons reflect the correction
- [ ] After submitting, click "Incorrect info?" again — confirm the rate-limit message appears
- [ ] Set `lastAnalysisRefresh` to >24h ago in browser storage — confirm the form reappears
- [ ] Without `onCompanyUpdate` wired (e.g. in tests with no prop) — confirm button is hidden
- [ ] `npm test` — all 332 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)