### PR TITLE
feat(contacts): data foundation — types, migration, useContacts hook

### DIFF
--- a/src/hooks/__tests__/useContacts.test.ts
+++ b/src/hooks/__tests__/useContacts.test.ts
@@ -1,0 +1,593 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useContacts } from '../useContacts'
+
+// ─── localStorage mock ────────────────────────────────────────────────────────
+
+const store: Record<string, string> = {}
+
+const mockLocalStorage = {
+  getItem: vi.fn((key: string) => store[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => { store[key] = value }),
+  removeItem: vi.fn((key: string) => { delete store[key] }),
+  clear: vi.fn(() => { Object.keys(store).forEach(k => delete store[k]) }),
+  key: vi.fn(),
+  get length() { return Object.keys(store).length },
+}
+
+// ─── Supabase mock ────────────────────────────────────────────────────────────
+// Fully chainable builder that is also thenable so every await resolves.
+
+function makeBuilder(data: unknown[] = []) {
+  const result = { data, error: null }
+  // Use an object with explicit method definitions so mockReturnThis works
+  const b = {
+    select:  vi.fn().mockReturnThis(),
+    eq:      vi.fn().mockReturnThis(),
+    order:   vi.fn().mockReturnThis(),
+    upsert:  vi.fn().mockReturnThis(),
+    delete:  vi.fn().mockReturnThis(),
+    // thenable — makes `await supabase.from(...).select(...).eq(...)` work
+    then: (resolve: (v: { data: unknown[]; error: null }) => void) =>
+      Promise.resolve().then(() => resolve(result)),
+  }
+  return b
+}
+
+vi.mock('../../lib/supabase', () => ({
+  createClientComponentClient: () => ({
+    from: vi.fn(() => makeBuilder()),
+  }),
+}))
+
+// ─── crypto.randomUUID stub ───────────────────────────────────────────────────
+
+let uuidCounter = 0
+const nextUUID = () => `test-uuid-${++uuidCounter}`
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  Object.defineProperty(window, 'localStorage', {
+    value: mockLocalStorage,
+    writable: true,
+    configurable: true,
+  })
+  mockLocalStorage.clear()
+  vi.clearAllMocks()
+  uuidCounter = 0
+
+  // Stub crypto.randomUUID
+  vi.spyOn(globalThis.crypto, 'randomUUID').mockImplementation(
+    nextUUID as () => `${string}-${string}-${string}-${string}-${string}`
+  )
+})
+
+// ─── Initial state ────────────────────────────────────────────────────────────
+
+describe('initial state', () => {
+  it('starts with empty contacts when storage and DB are empty', async () => {
+    const { result } = renderHook(() => useContacts({}))
+
+    await act(async () => {})
+
+    expect(result.current.contacts).toEqual([])
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('hydrates contacts from localStorage before Supabase resolves', () => {
+    const cached = JSON.stringify([{
+      id: 'cached-1',
+      user_id: 'u1',
+      company_id: 10,
+      name: 'Cached Person',
+      role: null,
+      linkedin_url: null,
+      source: 'alumni',
+      stage: 'identified',
+      type: 'unknown',
+      is_active: true,
+      emailed_at: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    }])
+    store['cosmos-contacts'] = cached
+
+    const { result } = renderHook(() => useContacts({ userId: 'u1' }))
+
+    // Immediately after render — cache should be visible before async resolves
+    expect(result.current.contacts).toHaveLength(1)
+    expect(result.current.contacts[0].name).toBe('Cached Person')
+  })
+})
+
+// ─── addContact ───────────────────────────────────────────────────────────────
+
+describe('addContact', () => {
+  it('adds a contact with default stage=identified and type=unknown', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    await act(async () => {
+      await result.current.addContact({
+        companyId: 1,
+        name: 'Alice',
+        source: 'alumni',
+      })
+    })
+
+    expect(result.current.contacts).toHaveLength(1)
+    const c = result.current.contacts[0]
+    expect(c.name).toBe('Alice')
+    expect(c.stage).toBe('identified')
+    expect(c.type).toBe('unknown')
+    expect(c.companyId).toBe(1)
+    expect(c.source).toBe('alumni')
+  })
+
+  it('first contact at a company becomes active automatically', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    await act(async () => {
+      await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' })
+    })
+
+    expect(result.current.contacts[0].isActive).toBe(true)
+  })
+
+  it('second contact at same company is NOT active automatically', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    await act(async () => {
+      await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' })
+    })
+    await act(async () => {
+      await result.current.addContact({ companyId: 1, name: 'Bob', source: 'first_degree' })
+    })
+
+    const companyContacts = result.current.contacts.filter(c => c.companyId === 1)
+    expect(companyContacts).toHaveLength(2)
+    const activeOnes = companyContacts.filter(c => c.isActive)
+    expect(activeOnes).toHaveLength(1)
+    expect(activeOnes[0].name).toBe('Alice')
+  })
+
+  it('first contact at a different company also becomes active independently', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    await act(async () => {
+      await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' })
+    })
+    await act(async () => {
+      await result.current.addContact({ companyId: 2, name: 'Bob', source: 'cold' })
+    })
+
+    const company1Active = result.current.contacts.find(c => c.companyId === 1 && c.isActive)
+    const company2Active = result.current.contacts.find(c => c.companyId === 2 && c.isActive)
+    expect(company1Active?.name).toBe('Alice')
+    expect(company2Active?.name).toBe('Bob')
+  })
+
+  it('stores optional role and linkedinUrl when provided', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    await act(async () => {
+      await result.current.addContact({
+        companyId: 1,
+        name: 'Alice',
+        source: 'group',
+        role: 'VP Engineering',
+        linkedinUrl: 'https://linkedin.com/in/alice',
+      })
+    })
+
+    expect(result.current.contacts[0].role).toBe('VP Engineering')
+    expect(result.current.contacts[0].linkedinUrl).toBe('https://linkedin.com/in/alice')
+  })
+
+  it('returns the newly created Contact object', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    let created: Awaited<ReturnType<typeof result.current.addContact>> | undefined
+    await act(async () => {
+      created = await result.current.addContact({ companyId: 5, name: 'Charlie', source: 'second_degree' })
+    })
+
+    expect(created).toBeDefined()
+    expect(created!.name).toBe('Charlie')
+    expect(created!.id).toBeTruthy()
+  })
+})
+
+// ─── updateContact ────────────────────────────────────────────────────────────
+
+describe('updateContact', () => {
+  it('updates the name of an existing contact', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    let id = ''
+    await act(async () => {
+      const c = await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' })
+      id = c.id
+    })
+    await act(async () => {
+      await result.current.updateContact(id, { name: 'Alice Updated' })
+    })
+
+    expect(result.current.contacts.find(c => c.id === id)?.name).toBe('Alice Updated')
+  })
+
+  it('updates the contact type', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    let id = ''
+    await act(async () => {
+      const c = await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' })
+      id = c.id
+    })
+    await act(async () => {
+      await result.current.updateContact(id, { type: 'booster' })
+    })
+
+    expect(result.current.contacts.find(c => c.id === id)?.type).toBe('booster')
+  })
+
+  it('does not affect other contacts', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    let id1 = '', id2 = ''
+    await act(async () => {
+      const c1 = await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' })
+      id1 = c1.id
+      const c2 = await result.current.addContact({ companyId: 1, name: 'Bob', source: 'cold' })
+      id2 = c2.id
+    })
+    await act(async () => {
+      await result.current.updateContact(id1, { name: 'Alice Updated' })
+    })
+
+    expect(result.current.contacts.find(c => c.id === id2)?.name).toBe('Bob')
+  })
+})
+
+// ─── removeContact ────────────────────────────────────────────────────────────
+
+describe('removeContact', () => {
+  it('removes the contact from the list', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    let id = ''
+    await act(async () => {
+      const c = await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' })
+      id = c.id
+    })
+    await act(async () => {
+      await result.current.removeContact(id)
+    })
+
+    expect(result.current.contacts.find(c => c.id === id)).toBeUndefined()
+  })
+
+  it('promotes the next contact to active when the active contact is removed', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    let id1 = '', id2 = ''
+    await act(async () => { const c = await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' }); id1 = c.id })
+    await act(async () => { const c = await result.current.addContact({ companyId: 1, name: 'Bob', source: 'cold' }); id2 = c.id })
+
+    // Alice is active, Bob is not
+    expect(result.current.contacts.find(c => c.id === id1)?.isActive).toBe(true)
+    expect(result.current.contacts.find(c => c.id === id2)?.isActive).toBe(false)
+
+    await act(async () => {
+      await result.current.removeContact(id1)
+    })
+
+    // Bob should now be active
+    expect(result.current.contacts.find(c => c.id === id2)?.isActive).toBe(true)
+  })
+
+  it('does NOT promote when a non-active contact is removed', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    let id1 = '', id2 = ''
+    await act(async () => { const c = await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' }); id1 = c.id })
+    await act(async () => { const c = await result.current.addContact({ companyId: 1, name: 'Bob', source: 'cold' }); id2 = c.id })
+
+    await act(async () => {
+      await result.current.removeContact(id2) // Bob is non-active
+    })
+
+    // Alice stays active
+    expect(result.current.contacts.find(c => c.id === id1)?.isActive).toBe(true)
+  })
+
+  it('does not affect contacts at other companies', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    let id1 = '', id2 = ''
+    await act(async () => { const c = await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' }); id1 = c.id })
+    await act(async () => { const c = await result.current.addContact({ companyId: 2, name: 'Bob', source: 'cold' }); id2 = c.id })
+    await act(async () => { await result.current.removeContact(id1) })
+
+    expect(result.current.contacts.find(c => c.id === id2)).toBeDefined()
+  })
+})
+
+// ─── setActiveContact ─────────────────────────────────────────────────────────
+
+describe('setActiveContact', () => {
+  it('makes the target contact active', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    let id2 = ''
+    await act(async () => { await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' }) })
+    await act(async () => { const c = await result.current.addContact({ companyId: 1, name: 'Bob', source: 'cold' }); id2 = c.id })
+    await act(async () => {
+      await result.current.setActiveContact(id2, 1)
+    })
+
+    expect(result.current.contacts.find(c => c.id === id2)?.isActive).toBe(true)
+  })
+
+  it('deactivates the previously active sibling at the same company', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    let id1 = '', id2 = ''
+    await act(async () => {
+      const c1 = await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' })
+      id1 = c1.id
+      const c2 = await result.current.addContact({ companyId: 1, name: 'Bob', source: 'cold' })
+      id2 = c2.id
+    })
+    await act(async () => {
+      await result.current.setActiveContact(id2, 1)
+    })
+
+    expect(result.current.contacts.find(c => c.id === id1)?.isActive).toBe(false)
+  })
+
+  it('does not change active state of contacts at other companies', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    let id1 = '', id2 = '', id3 = ''
+    await act(async () => {
+      const c1 = await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' })
+      id1 = c1.id
+      const c2 = await result.current.addContact({ companyId: 1, name: 'Bob', source: 'cold' })
+      id2 = c2.id
+      const c3 = await result.current.addContact({ companyId: 2, name: 'Carol', source: 'group' })
+      id3 = c3.id
+    })
+    await act(async () => {
+      await result.current.setActiveContact(id2, 1)
+    })
+
+    // Carol at company 2 should remain active
+    expect(result.current.contacts.find(c => c.id === id3)?.isActive).toBe(true)
+  })
+})
+
+// ─── advanceStage ─────────────────────────────────────────────────────────────
+
+describe('advanceStage', () => {
+  it('advances stage from identified to emailed', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    let id = ''
+    await act(async () => {
+      const c = await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' })
+      id = c.id
+    })
+    await act(async () => {
+      await result.current.advanceStage(id)
+    })
+
+    expect(result.current.contacts.find(c => c.id === id)?.stage).toBe('emailed')
+  })
+
+  it('sets emailedAt when advancing to emailed', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    let id = ''
+    await act(async () => {
+      const c = await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' })
+      id = c.id
+    })
+    await act(async () => {
+      await result.current.advanceStage(id)
+    })
+
+    expect(result.current.contacts.find(c => c.id === id)?.emailedAt).not.toBeNull()
+  })
+
+  it('does NOT overwrite emailedAt on subsequent advances', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    let id = ''
+    await act(async () => {
+      const c = await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' })
+      id = c.id
+    })
+    // Advance to emailed
+    await act(async () => { await result.current.advanceStage(id) })
+    const emailedAt = result.current.contacts.find(c => c.id === id)?.emailedAt
+
+    // Advance to day3_check
+    await act(async () => { await result.current.advanceStage(id) })
+
+    expect(result.current.contacts.find(c => c.id === id)?.emailedAt).toBe(emailedAt)
+  })
+
+  it('advances through the full stage sequence', async () => {
+    const stages = ['identified', 'emailed', 'day3_check', 'day7_followup', 'informational_scheduled', 'completed']
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    let id = ''
+    await act(async () => {
+      const c = await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' })
+      id = c.id
+    })
+
+    for (let i = 1; i < stages.length; i++) {
+      await act(async () => { await result.current.advanceStage(id) })
+      expect(result.current.contacts.find(c => c.id === id)?.stage).toBe(stages[i])
+    }
+  })
+
+  it('does nothing when contact is already at completed stage', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    let id = ''
+    await act(async () => {
+      const c = await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' })
+      id = c.id
+    })
+
+    // Advance all the way to completed (5 advances)
+    for (let i = 0; i < 5; i++) {
+      await act(async () => { await result.current.advanceStage(id) })
+    }
+    expect(result.current.contacts.find(c => c.id === id)?.stage).toBe('completed')
+
+    // One more advance — should stay at completed
+    await act(async () => { await result.current.advanceStage(id) })
+    expect(result.current.contacts.find(c => c.id === id)?.stage).toBe('completed')
+  })
+
+  it('does nothing when contact id does not exist', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    await act(async () => {
+      await result.current.advanceStage('nonexistent-id')
+    })
+
+    expect(result.current.contacts).toHaveLength(0)
+  })
+})
+
+// ─── getContactsForCompany ────────────────────────────────────────────────────
+
+describe('getContactsForCompany', () => {
+  it('returns only contacts for the given company', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    await act(async () => {
+      await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' })
+      await result.current.addContact({ companyId: 2, name: 'Bob', source: 'cold' })
+    })
+
+    const company1 = result.current.getContactsForCompany(1)
+    expect(company1).toHaveLength(1)
+    expect(company1[0].name).toBe('Alice')
+  })
+
+  it('returns empty array when company has no contacts', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    expect(result.current.getContactsForCompany(99)).toEqual([])
+  })
+})
+
+// ─── getActiveContact ─────────────────────────────────────────────────────────
+
+describe('getActiveContact', () => {
+  it('returns the active contact for a company', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    await act(async () => {
+      await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' })
+      await result.current.addContact({ companyId: 1, name: 'Bob', source: 'cold' })
+    })
+
+    expect(result.current.getActiveContact(1)?.name).toBe('Alice')
+  })
+
+  it('returns undefined when company has no contacts', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    expect(result.current.getActiveContact(99)).toBeUndefined()
+  })
+})
+
+// ─── getCompanyHealth ─────────────────────────────────────────────────────────
+
+describe('getCompanyHealth', () => {
+  it('returns "none" for a company with no contacts', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    expect(result.current.getCompanyHealth(1)).toBe('none')
+  })
+
+  it('returns "in_progress" for a company with an active unknown contact', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    await act(async () => {
+      await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' })
+    })
+
+    expect(result.current.getCompanyHealth(1)).toBe('in_progress')
+  })
+
+  it('returns "booster" after marking a contact as booster', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    let id = ''
+    await act(async () => {
+      const c = await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' })
+      id = c.id
+    })
+    await act(async () => {
+      await result.current.updateContact(id, { type: 'booster' })
+    })
+
+    expect(result.current.getCompanyHealth(1)).toBe('booster')
+  })
+
+  it('returns "informational" after advancing to informational_scheduled', async () => {
+    const { result } = renderHook(() => useContacts({}))
+    await act(async () => {})
+
+    let id = ''
+    await act(async () => {
+      const c = await result.current.addContact({ companyId: 1, name: 'Alice', source: 'alumni' })
+      id = c.id
+    })
+
+    // Advance through identified → emailed → day3 → day7 → informational_scheduled
+    for (let i = 0; i < 4; i++) {
+      await act(async () => { await result.current.advanceStage(id) })
+    }
+
+    expect(result.current.getCompanyHealth(1)).toBe('informational')
+  })
+})

--- a/src/hooks/useContacts.ts
+++ b/src/hooks/useContacts.ts
@@ -1,0 +1,306 @@
+/**
+ * Hook for Contact Management & 3B7 Outreach Tracking (Epic #148).
+ * Follows the same three-layer persistence pattern as useWatchlist:
+ *   local state → localStorage → Supabase
+ */
+
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
+import { createClientComponentClient } from '../lib/supabase'
+import {
+  Contact,
+  ContactRecord,
+  ContactSource,
+  ContactStage,
+  ContactType,
+  CompanyContactHealth,
+  CreateContactInput,
+  UpdateContactInput,
+  contactFromRecord,
+  deriveCompanyHealth,
+} from '../types/contacts'
+
+const STORAGE_KEY = 'cosmos-contacts'
+
+// ─── localStorage helpers ────────────────────────────────────────────────────
+
+function loadFromStorage(): ContactRecord[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as ContactRecord[]) : []
+  } catch {
+    return []
+  }
+}
+
+function saveToStorage(records: ContactRecord[]): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(records))
+  } catch {
+    console.warn('useContacts: failed to persist to localStorage')
+  }
+}
+
+// ─── Hook interface ──────────────────────────────────────────────────────────
+
+interface UseContactsOptions {
+  userId?: string
+}
+
+interface UseContactsReturn {
+  contacts: Contact[]
+  isLoading: boolean
+  error: string | null
+  // Queries
+  getContactsForCompany: (companyId: number) => Contact[]
+  getActiveContact: (companyId: number) => Contact | undefined
+  getCompanyHealth: (companyId: number) => CompanyContactHealth
+  // Mutations
+  addContact: (input: CreateContactInput) => Promise<Contact>
+  updateContact: (id: string, updates: UpdateContactInput) => Promise<void>
+  removeContact: (id: string) => Promise<void>
+  setActiveContact: (id: string, companyId: number) => Promise<void>
+  advanceStage: (id: string) => Promise<void>
+}
+
+// Ordered stages for advanceStage
+const STAGE_ORDER: ContactStage[] = [
+  'identified',
+  'emailed',
+  'day3_check',
+  'day7_followup',
+  'informational_scheduled',
+  'completed',
+]
+
+// ─── Hook ────────────────────────────────────────────────────────────────────
+
+export function useContacts({ userId }: UseContactsOptions): UseContactsReturn {
+  const [records, setRecords] = useState<ContactRecord[]>([])
+  // Keep a ref in sync so mutations always read the latest records without
+  // stale closure issues when multiple calls happen before React re-renders.
+  const recordsRef = useRef<ContactRecord[]>(records)
+  recordsRef.current = records
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // ── Load: localStorage first, then sync from Supabase ──────────────────────
+  useEffect(() => {
+    const cached = loadFromStorage()
+    if (cached.length > 0) {
+      setRecords(cached)
+      setIsLoading(false)
+    }
+
+    if (!userId) {
+      setIsLoading(false)
+      return
+    }
+
+    const supabase = createClientComponentClient()
+    if (!supabase) {
+      setIsLoading(false)
+      return
+    }
+
+    supabase
+      .from('contacts')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: true })
+      .then(({ data, error: dbError }) => {
+        if (dbError) {
+          console.warn('useContacts: Supabase fetch failed, using cache', dbError.message)
+          setIsLoading(false)
+          return
+        }
+        const fresh = (data ?? []) as ContactRecord[]
+        setRecords(fresh)
+        saveToStorage(fresh)
+        setIsLoading(false)
+      })
+  }, [userId])
+
+  // ── Internal helpers ────────────────────────────────────────────────────────
+
+  const persist = useCallback(
+    async (next: ContactRecord[]) => {
+      recordsRef.current = next
+      setRecords(next)
+      saveToStorage(next)
+
+      if (!userId) return
+
+      const supabase = createClientComponentClient()
+      if (!supabase) return
+
+      // Upsert the full set for this user — simple and correct for this data size
+      const { error: dbError } = await supabase
+        .from('contacts')
+        .upsert(next.filter(r => r.user_id === userId), { onConflict: 'id' })
+
+      if (dbError) {
+        console.warn('useContacts: Supabase upsert failed', dbError.message)
+        setError('Failed to save contacts to database')
+      } else {
+        setError(null)
+      }
+    },
+    [userId]
+  )
+
+  // ── Queries ─────────────────────────────────────────────────────────────────
+
+  const contacts = useMemo<Contact[]>(() => records.map(contactFromRecord), [records])
+
+  const getContactsForCompany = useCallback(
+    (companyId: number) => contacts.filter(c => c.companyId === companyId),
+    [contacts]
+  )
+
+  const getActiveContact = useCallback(
+    (companyId: number) =>
+      contacts.find(c => c.companyId === companyId && c.isActive),
+    [contacts]
+  )
+
+  const getCompanyHealth = useCallback(
+    (companyId: number): CompanyContactHealth =>
+      deriveCompanyHealth(getContactsForCompany(companyId)),
+    [getContactsForCompany]
+  )
+
+  // ── Mutations ───────────────────────────────────────────────────────────────
+
+  const addContact = useCallback(
+    async (input: CreateContactInput): Promise<Contact> => {
+      const current = recordsRef.current
+      const now = new Date().toISOString()
+      const hasExistingActive = current.some(
+        r => r.company_id === input.companyId && r.is_active
+      )
+
+      const newRecord: ContactRecord = {
+        id: crypto.randomUUID(),
+        user_id: userId ?? 'local',
+        company_id: input.companyId,
+        name: input.name,
+        role: input.role ?? null,
+        linkedin_url: input.linkedinUrl ?? null,
+        source: input.source,
+        stage: 'identified',
+        type: 'unknown',
+        is_active: !hasExistingActive, // first contact becomes active automatically
+        emailed_at: null,
+        created_at: now,
+        updated_at: now,
+      }
+
+      await persist([...current, newRecord])
+      return contactFromRecord(newRecord)
+    },
+    [userId, persist]
+  )
+
+  const updateContact = useCallback(
+    async (id: string, updates: UpdateContactInput): Promise<void> => {
+      const now = new Date().toISOString()
+      const next = recordsRef.current.map(r => {
+        if (r.id !== id) return r
+        return {
+          ...r,
+          ...(updates.name !== undefined && { name: updates.name }),
+          ...(updates.role !== undefined && { role: updates.role ?? null }),
+          ...(updates.linkedinUrl !== undefined && { linkedin_url: updates.linkedinUrl ?? null }),
+          ...(updates.source !== undefined && { source: updates.source as ContactSource }),
+          ...(updates.stage !== undefined && { stage: updates.stage as ContactStage }),
+          ...(updates.type !== undefined && { type: updates.type as ContactType }),
+          ...(updates.isActive !== undefined && { is_active: updates.isActive }),
+          ...(updates.emailedAt !== undefined && { emailed_at: updates.emailedAt ?? null }),
+          updated_at: now,
+        }
+      })
+      await persist(next)
+    },
+    [persist]
+  )
+
+  const removeContact = useCallback(
+    async (id: string): Promise<void> => {
+      const current = recordsRef.current
+      const removed = current.find(r => r.id === id)
+      const next = current.filter(r => r.id !== id)
+
+      // If the removed contact was active, promote the earliest remaining contact
+      if (removed?.is_active) {
+        const sibling = next.find(r => r.company_id === removed.company_id)
+        if (sibling) {
+          const idx = next.indexOf(sibling)
+          next[idx] = { ...sibling, is_active: true, updated_at: new Date().toISOString() }
+        }
+      }
+
+      await persist(next)
+
+      // Hard delete from Supabase (upsert won't remove deleted rows)
+      if (userId) {
+        const supabase = createClientComponentClient()
+        if (supabase) {
+          await supabase.from('contacts').delete().eq('id', id).eq('user_id', userId)
+        }
+      }
+    },
+    [userId, persist]
+  )
+
+  const setActiveContact = useCallback(
+    async (id: string, companyId: number): Promise<void> => {
+      const now = new Date().toISOString()
+      const next = recordsRef.current.map(r => {
+        if (r.company_id !== companyId) return r
+        return { ...r, is_active: r.id === id, updated_at: now }
+      })
+      await persist(next)
+    },
+    [persist]
+  )
+
+  const advanceStage = useCallback(
+    async (id: string): Promise<void> => {
+      const current = recordsRef.current
+      const record = current.find(r => r.id === id)
+      if (!record) return
+
+      const currentIdx = STAGE_ORDER.indexOf(record.stage)
+      if (currentIdx === -1 || currentIdx === STAGE_ORDER.length - 1) return
+
+      const nextStage = STAGE_ORDER[currentIdx + 1]
+      const now = new Date().toISOString()
+      const emailedAt =
+        nextStage === 'emailed' ? now : record.emailed_at
+
+      const next = current.map(r =>
+        r.id === id
+          ? { ...r, stage: nextStage, emailed_at: emailedAt, updated_at: now }
+          : r
+      )
+      await persist(next)
+    },
+    [persist]
+  )
+
+  return {
+    contacts,
+    isLoading,
+    error,
+    getContactsForCompany,
+    getActiveContact,
+    getCompanyHealth,
+    addContact,
+    updateContact,
+    removeContact,
+    setActiveContact,
+    advanceStage,
+  }
+}

--- a/src/types/__tests__/contacts.test.ts
+++ b/src/types/__tests__/contacts.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest'
+import {
+  Contact,
+  ContactRecord,
+  contactFromRecord,
+  contactToRecord,
+  deriveCompanyHealth,
+} from '../contacts'
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeRecord(overrides: Partial<ContactRecord> = {}): ContactRecord {
+  return {
+    id: 'rec-1',
+    user_id: 'user-abc',
+    company_id: 42,
+    name: 'Jane Smith',
+    role: 'Engineering Manager',
+    linkedin_url: 'https://linkedin.com/in/janesmith',
+    source: 'alumni',
+    stage: 'identified',
+    type: 'unknown',
+    is_active: true,
+    emailed_at: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeContact(overrides: Partial<Contact> = {}): Contact {
+  return {
+    id: 'rec-1',
+    userId: 'user-abc',
+    companyId: 42,
+    name: 'Jane Smith',
+    role: 'Engineering Manager',
+    linkedinUrl: 'https://linkedin.com/in/janesmith',
+    source: 'alumni',
+    stage: 'identified',
+    type: 'unknown',
+    isActive: true,
+    emailedAt: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+// ─── contactFromRecord ────────────────────────────────────────────────────────
+
+describe('contactFromRecord', () => {
+  it('maps all snake_case fields to camelCase correctly', () => {
+    const record = makeRecord()
+    const contact = contactFromRecord(record)
+
+    expect(contact.id).toBe(record.id)
+    expect(contact.userId).toBe(record.user_id)
+    expect(contact.companyId).toBe(record.company_id)
+    expect(contact.name).toBe(record.name)
+    expect(contact.role).toBe(record.role)
+    expect(contact.linkedinUrl).toBe(record.linkedin_url)
+    expect(contact.source).toBe(record.source)
+    expect(contact.stage).toBe(record.stage)
+    expect(contact.type).toBe(record.type)
+    expect(contact.isActive).toBe(record.is_active)
+    expect(contact.emailedAt).toBe(record.emailed_at)
+    expect(contact.createdAt).toBe(record.created_at)
+    expect(contact.updatedAt).toBe(record.updated_at)
+  })
+
+  it('preserves null optional fields', () => {
+    const record = makeRecord({ role: null, linkedin_url: null, emailed_at: null })
+    const contact = contactFromRecord(record)
+
+    expect(contact.role).toBeNull()
+    expect(contact.linkedinUrl).toBeNull()
+    expect(contact.emailedAt).toBeNull()
+  })
+
+  it('preserves non-null optional fields', () => {
+    const record = makeRecord({
+      role: 'VP of Engineering',
+      linkedin_url: 'https://linkedin.com/in/someone',
+      emailed_at: '2026-02-01T09:00:00Z',
+    })
+    const contact = contactFromRecord(record)
+
+    expect(contact.role).toBe('VP of Engineering')
+    expect(contact.linkedinUrl).toBe('https://linkedin.com/in/someone')
+    expect(contact.emailedAt).toBe('2026-02-01T09:00:00Z')
+  })
+})
+
+// ─── contactToRecord ────────────────────────────────────────────────────────
+
+describe('contactToRecord', () => {
+  it('maps all camelCase fields to snake_case correctly', () => {
+    const contact = makeContact()
+    const record = contactToRecord(contact)
+
+    expect(record.id).toBe(contact.id)
+    expect(record.user_id).toBe(contact.userId)
+    expect(record.company_id).toBe(contact.companyId)
+    expect(record.name).toBe(contact.name)
+    expect(record.role).toBe(contact.role)
+    expect(record.linkedin_url).toBe(contact.linkedinUrl)
+    expect(record.source).toBe(contact.source)
+    expect(record.stage).toBe(contact.stage)
+    expect(record.type).toBe(contact.type)
+    expect(record.is_active).toBe(contact.isActive)
+    expect(record.emailed_at).toBe(contact.emailedAt)
+    expect(record.created_at).toBe(contact.createdAt)
+    expect(record.updated_at).toBe(contact.updatedAt)
+  })
+
+  it('preserves null optional fields', () => {
+    const contact = makeContact({ role: null, linkedinUrl: null, emailedAt: null })
+    const record = contactToRecord(contact)
+
+    expect(record.role).toBeNull()
+    expect(record.linkedin_url).toBeNull()
+    expect(record.emailed_at).toBeNull()
+  })
+})
+
+// ─── round-trip ──────────────────────────────────────────────────────────────
+
+describe('contactFromRecord / contactToRecord round-trip', () => {
+  it('record → contact → record produces identical output', () => {
+    const original = makeRecord()
+    expect(contactToRecord(contactFromRecord(original))).toEqual(original)
+  })
+
+  it('contact → record → contact produces identical output', () => {
+    const original = makeContact()
+    expect(contactFromRecord(contactToRecord(original))).toEqual(original)
+  })
+})
+
+// ─── deriveCompanyHealth ──────────────────────────────────────────────────────
+
+describe('deriveCompanyHealth', () => {
+  it('returns "none" when there are no contacts', () => {
+    expect(deriveCompanyHealth([])).toBe('none')
+  })
+
+  it('returns "booster" when any contact is typed as booster', () => {
+    const contacts = [
+      makeContact({ type: 'booster', isActive: true }),
+      makeContact({ id: 'rec-2', type: 'curmudgeon', isActive: false }),
+    ]
+    expect(deriveCompanyHealth(contacts)).toBe('booster')
+  })
+
+  it('booster takes priority over informational_scheduled stage', () => {
+    const contacts = [
+      makeContact({ type: 'booster', stage: 'emailed' }),
+      makeContact({ id: 'rec-2', type: 'unknown', stage: 'informational_scheduled' }),
+    ]
+    expect(deriveCompanyHealth(contacts)).toBe('booster')
+  })
+
+  it('returns "informational" when any contact has informational_scheduled stage and no booster', () => {
+    const contacts = [
+      makeContact({ type: 'unknown', stage: 'informational_scheduled', isActive: true }),
+    ]
+    expect(deriveCompanyHealth(contacts)).toBe('informational')
+  })
+
+  it('returns "in_progress" when there is an active contact and no booster or informational', () => {
+    const contacts = [
+      makeContact({ type: 'unknown', stage: 'emailed', isActive: true }),
+    ]
+    expect(deriveCompanyHealth(contacts)).toBe('in_progress')
+  })
+
+  it('returns "stalled" when no contact is active', () => {
+    const contacts = [
+      makeContact({ isActive: false, stage: 'identified' }),
+      makeContact({ id: 'rec-2', isActive: false, stage: 'emailed' }),
+    ]
+    expect(deriveCompanyHealth(contacts)).toBe('stalled')
+  })
+
+  it('returns "stalled" when all contacts are curmudgeons', () => {
+    const contacts = [
+      makeContact({ type: 'curmudgeon', isActive: true }),
+      makeContact({ id: 'rec-2', type: 'curmudgeon', isActive: false }),
+    ]
+    expect(deriveCompanyHealth(contacts)).toBe('stalled')
+  })
+
+  it('returns "stalled" when active contact is a curmudgeon but another is not', () => {
+    // All contacts must be curmudgeons for "stalled" — if even one is not, it's in_progress
+    const contacts = [
+      makeContact({ type: 'curmudgeon', isActive: true }),
+      makeContact({ id: 'rec-2', type: 'obligate', isActive: false }),
+    ]
+    // allCurmudgeons is false, hasActive is true → in_progress
+    expect(deriveCompanyHealth(contacts)).toBe('in_progress')
+  })
+
+  it('returns "in_progress" with a mix of obligates and unknowns when active', () => {
+    const contacts = [
+      makeContact({ type: 'obligate', isActive: true }),
+      makeContact({ id: 'rec-2', type: 'unknown', isActive: false }),
+    ]
+    expect(deriveCompanyHealth(contacts)).toBe('in_progress')
+  })
+
+  it('single identified contact with no active flag returns stalled', () => {
+    expect(deriveCompanyHealth([makeContact({ isActive: false, stage: 'identified' })])).toBe('stalled')
+  })
+
+  it('single active identified contact returns in_progress', () => {
+    expect(deriveCompanyHealth([makeContact({ isActive: true, stage: 'identified' })])).toBe('in_progress')
+  })
+})

--- a/src/types/contacts.ts
+++ b/src/types/contacts.ts
@@ -1,0 +1,159 @@
+/**
+ * Types for the Contact Management & 3B7 Outreach Tracking epic.
+ * Based on the LAMP methodology from "The 2-Hour Job Search" by Steve Dalton.
+ */
+
+/**
+ * Where the user is in the outreach process with a contact.
+ * Linear progression — each step unlocks the next.
+ */
+export type ContactStage =
+  | 'identified'        // Found the person, not yet emailed
+  | 'emailed'           // First email sent (starts the 3B7 clock)
+  | 'day3_check'        // Day 3: no reply yet, try a second contact at same company
+  | 'day7_followup'     // Day 7: follow up with original contact
+  | 'informational_scheduled' // They agreed to an informational interview
+  | 'completed'         // Informational done
+
+/**
+ * What the user has learned about a contact over time.
+ * Independent from stage — classification can change as the relationship develops.
+ */
+export type ContactType =
+  | 'unknown'           // Default — not yet classified
+  | 'booster'           // Genuinely wants to help (~10-20% of contacts)
+  | 'obligate'          // Slow, unreliable responder
+  | 'curmudgeon'        // Never responds
+
+/**
+ * How the user knows this contact (maps to LAMP prioritization order).
+ */
+export type ContactSource =
+  | 'alumni'            // Shared alma mater — highest priority
+  | 'first_degree'      // Direct LinkedIn connection
+  | 'second_degree'     // Mutual connection
+  | 'group'             // Shared LinkedIn group
+  | 'cold'              // Cold/fan mail — lowest priority
+
+/**
+ * Company-level health derived from the contacts at that company.
+ * Visible as a color badge on the graph node.
+ *
+ * Green  — Booster found
+ * Cyan   — Informational interview scheduled
+ * Purple — Outreach in progress (no Booster yet)
+ * Gray   — Contacts identified but no active outreach, or all Curmudgeons
+ * None   — No contacts added
+ */
+export type CompanyContactHealth = 'booster' | 'informational' | 'in_progress' | 'stalled' | 'none'
+
+/**
+ * A single contact at a company.
+ */
+export interface Contact {
+  id: string
+  userId: string
+  companyId: number
+  name: string
+  role: string | null
+  linkedinUrl: string | null
+  source: ContactSource
+  stage: ContactStage
+  type: ContactType
+  isActive: boolean       // Only one contact per company should be active at a time
+  emailedAt: string | null  // ISO timestamp — set when stage moves to 'emailed'
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * Fields required to create a new contact.
+ */
+export type CreateContactInput = Pick<Contact, 'companyId' | 'name' | 'source'> & {
+  role?: string
+  linkedinUrl?: string
+}
+
+/**
+ * Fields that can be updated on an existing contact.
+ */
+export type UpdateContactInput = Partial<
+  Pick<Contact, 'name' | 'role' | 'linkedinUrl' | 'source' | 'stage' | 'type' | 'isActive' | 'emailedAt'>
+>
+
+/**
+ * localStorage / serialization shape (snake_case to match DB row).
+ */
+export interface ContactRecord {
+  id: string
+  user_id: string
+  company_id: number
+  name: string
+  role: string | null
+  linkedin_url: string | null
+  source: ContactSource
+  stage: ContactStage
+  type: ContactType
+  is_active: boolean
+  emailed_at: string | null
+  created_at: string
+  updated_at: string
+}
+
+/** Maps a DB/storage record to the camelCase Contact interface. */
+export function contactFromRecord(r: ContactRecord): Contact {
+  return {
+    id: r.id,
+    userId: r.user_id,
+    companyId: r.company_id,
+    name: r.name,
+    role: r.role,
+    linkedinUrl: r.linkedin_url,
+    source: r.source,
+    stage: r.stage,
+    type: r.type,
+    isActive: r.is_active,
+    emailedAt: r.emailed_at,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  }
+}
+
+/** Maps a camelCase Contact back to a DB/storage record. */
+export function contactToRecord(c: Contact): ContactRecord {
+  return {
+    id: c.id,
+    user_id: c.userId,
+    company_id: c.companyId,
+    name: c.name,
+    role: c.role,
+    linkedin_url: c.linkedinUrl,
+    source: c.source,
+    stage: c.stage,
+    type: c.type,
+    is_active: c.isActive,
+    emailed_at: c.emailedAt,
+    created_at: c.createdAt,
+    updated_at: c.updatedAt,
+  }
+}
+
+/**
+ * Derives company-level health from its contacts.
+ */
+export function deriveCompanyHealth(contacts: Contact[]): CompanyContactHealth {
+  if (contacts.length === 0) return 'none'
+
+  const hasBooster = contacts.some(c => c.type === 'booster')
+  if (hasBooster) return 'booster'
+
+  const hasInformational = contacts.some(c => c.stage === 'informational_scheduled')
+  if (hasInformational) return 'informational'
+
+  const allCurmudgeons = contacts.every(c => c.type === 'curmudgeon')
+  const hasActive = contacts.some(c => c.isActive)
+
+  if (!hasActive || allCurmudgeons) return 'stalled'
+
+  return 'in_progress'
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -44,5 +44,13 @@ export interface UserInvitation {
   created_at: string
 }
 
+export interface UserContacts {
+  id: string
+  user_id: string
+  contacts: import('./contacts').ContactRecord[]
+  created_at: string
+  updated_at: string
+}
+
 // Re-export existing types from the main types file
 export type { Company, UserCMF } from './index'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -140,5 +140,8 @@ export interface CompanyDetailPanelProps {
 // Export watchlist types
 export * from './watchlist';
 
+// Export contact types
+export * from './contacts';
+
 // Export LLM types
 export * from '../utils/llm/types';

--- a/supabase/migrations/004_contacts.sql
+++ b/supabase/migrations/004_contacts.sql
@@ -1,0 +1,100 @@
+-- ============================================================================
+-- 004_contacts.sql
+-- Contact Management & 3B7 Outreach Tracking (Epic #148)
+-- ============================================================================
+-- Stores contacts that users add to companies in their graph.
+-- One row per contact. Multiple contacts per (user, company) are allowed;
+-- only one should have is_active = true per company at a time (enforced in app).
+-- ============================================================================
+
+CREATE TYPE contact_stage AS ENUM (
+  'identified',
+  'emailed',
+  'day3_check',
+  'day7_followup',
+  'informational_scheduled',
+  'completed'
+);
+
+CREATE TYPE contact_type AS ENUM (
+  'unknown',
+  'booster',
+  'obligate',
+  'curmudgeon'
+);
+
+CREATE TYPE contact_source AS ENUM (
+  'alumni',
+  'first_degree',
+  'second_degree',
+  'group',
+  'cold'
+);
+
+CREATE TABLE IF NOT EXISTS contacts (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  company_id   INTEGER NOT NULL,           -- References Company.id from app data (not a FK to a table)
+  name         TEXT NOT NULL,
+  role         TEXT,
+  linkedin_url TEXT,
+  source       contact_source NOT NULL DEFAULT 'cold',
+  stage        contact_stage  NOT NULL DEFAULT 'identified',
+  type         contact_type   NOT NULL DEFAULT 'unknown',
+  is_active    BOOLEAN NOT NULL DEFAULT FALSE,
+  emailed_at   TIMESTAMPTZ,               -- Set when stage moves to 'emailed'
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Fast lookups by user + company (the most common query pattern)
+CREATE INDEX contacts_user_company_idx ON contacts (user_id, company_id);
+
+-- Fast lookup of active contact per company
+CREATE INDEX contacts_user_active_idx ON contacts (user_id, company_id, is_active)
+  WHERE is_active = TRUE;
+
+-- Auto-update updated_at on row changes
+CREATE OR REPLACE FUNCTION update_contacts_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER contacts_updated_at
+  BEFORE UPDATE ON contacts
+  FOR EACH ROW EXECUTE FUNCTION update_contacts_updated_at();
+
+-- ============================================================================
+-- ROW LEVEL SECURITY
+-- ============================================================================
+
+ALTER TABLE contacts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their own contacts" ON contacts
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert their own contacts" ON contacts
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update their own contacts" ON contacts
+  FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete their own contacts" ON contacts
+  FOR DELETE USING (auth.uid() = user_id);
+
+CREATE POLICY "Admins can access all contacts" ON contacts
+  FOR ALL USING (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE id = auth.uid() AND role = 'admin'
+    )
+  );
+
+-- ============================================================================
+-- GRANTS
+-- ============================================================================
+
+GRANT ALL ON contacts TO authenticated;


### PR DESCRIPTION
## Summary

- **`src/types/contacts.ts`** — All contact types: `ContactStage`, `ContactType`, `ContactSource`, `CompanyContactHealth`, `Contact`, `ContactRecord`, `CreateContactInput`, `UpdateContactInput`, `contactFromRecord`, `contactToRecord`, `deriveCompanyHealth()`
- **`supabase/migrations/004_contacts.sql`** — `contacts` table with enums, indexes on `(user_id, company_id)`, RLS policies, and `updated_at` trigger
- **`src/hooks/useContacts.ts`** — Three-layer persistence hook (localStorage → Supabase) with `useRef` pattern to prevent stale closure bugs across rapid mutations
- Types wired into `src/types/index.ts` and `src/types/database.ts`

## Test plan

- [x] 18 pure function tests for `contacts.ts` (`contactFromRecord`, `contactToRecord`, round-trips, all `deriveCompanyHealth` branches)
- [x] 32 hook tests for `useContacts` (initial state, localStorage hydration, `addContact`, `updateContact`, `removeContact`, `setActiveContact`, `advanceStage`, query functions)
- [x] All 396 tests pass (`npm test`)

## Part of

Epic #148 — Company Contact Management & 3B7 Outreach Tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)