### PR TITLE
fix(auth): replace raw Supabase errors with descriptive login messages

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -4,6 +4,7 @@ import { createClientComponentClient } from '../../src/lib/supabase'
 import { useRouter } from 'next/navigation'
 import { LogIn, Mail, Lock, Loader2, Sparkles } from 'lucide-react'
 import { CosmosBackground } from '../../src/components/CosmosBackground'
+import { getLoginErrorMessage, getPasswordResetErrorMessage } from '../../src/utils/authErrors'
 
 export default function LoginPage() {
   const [email, setEmail] = useState('')
@@ -26,15 +27,15 @@ export default function LoginPage() {
       return
     }
     
-    const { error } = await supabase.auth.signInWithPassword({
-      email,
-      password,
-    })
-
-    if (error) {
-      setError(error.message)
-    } else {
-      router.push('/explorer')
+    try {
+      const { error } = await supabase.auth.signInWithPassword({ email, password })
+      if (error) {
+        setError(getLoginErrorMessage(error))
+      } else {
+        router.push('/explorer')
+      }
+    } catch (err) {
+      setError(getLoginErrorMessage(err))
     }
     setLoading(false)
   }
@@ -52,14 +53,17 @@ export default function LoginPage() {
     }
     
     const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || window.location.origin
-    const { error } = await supabase.auth.resetPasswordForEmail(email, {
-      redirectTo: `${siteUrl}/reset-password`
-    })
-
-    if (error) {
-      setError(error.message)
-    } else {
-      setResetSent(true)
+    try {
+      const { error } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo: `${siteUrl}/reset-password`
+      })
+      if (error) {
+        setError(getPasswordResetErrorMessage(error))
+      } else {
+        setResetSent(true)
+      }
+    } catch (err) {
+      setError(getPasswordResetErrorMessage(err))
     }
     setLoading(false)
   }

--- a/src/components/__tests__/LoginPage.test.tsx
+++ b/src/components/__tests__/LoginPage.test.tsx
@@ -1,0 +1,176 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+// --- mocks ---
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('../../components/CosmosBackground', () => ({
+  CosmosBackground: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const mockSignIn = vi.fn();
+const mockResetPassword = vi.fn();
+
+vi.mock('../../lib/supabase', () => ({
+  createClientComponentClient: () => ({
+    auth: {
+      signInWithPassword: mockSignIn,
+      resetPasswordForEmail: mockResetPassword,
+    },
+  }),
+}));
+
+// --- component under test (dynamic import to pick up mocks) ---
+let LoginPage: React.ComponentType;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  const mod = await import('../../../app/login/page');
+  LoginPage = mod.default;
+});
+
+// --- helpers ---
+function fillAndSubmit(email = 'user@example.com', password = 'secret') {
+  fireEvent.change(screen.getByPlaceholderText('you@example.com'), {
+    target: { value: email },
+  });
+  fireEvent.change(screen.getByPlaceholderText('Enter your password'), {
+    target: { value: password },
+  });
+  fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+}
+
+// --- tests ---
+
+describe('LoginPage error messages', () => {
+  describe('sign-in errors', () => {
+    it('shows a human-readable message for Failed to fetch', async () => {
+      mockSignIn.mockResolvedValue({ error: { message: 'Failed to fetch' } });
+      render(<LoginPage />);
+      fillAndSubmit();
+      await waitFor(() =>
+        expect(screen.getByText(/Unable to reach/i)).toBeInTheDocument()
+      );
+    });
+
+    it('does not show raw "Failed to fetch" to the user', async () => {
+      mockSignIn.mockResolvedValue({ error: { message: 'Failed to fetch' } });
+      render(<LoginPage />);
+      fillAndSubmit();
+      await waitFor(() =>
+        expect(screen.queryByText('Failed to fetch')).not.toBeInTheDocument()
+      );
+    });
+
+    it('shows credential error for invalid login', async () => {
+      mockSignIn.mockResolvedValue({ error: { message: 'Invalid login credentials' } });
+      render(<LoginPage />);
+      fillAndSubmit();
+      await waitFor(() =>
+        expect(screen.getByText(/Incorrect email or password/i)).toBeInTheDocument()
+      );
+    });
+
+    it('shows email verification prompt when email not confirmed', async () => {
+      mockSignIn.mockResolvedValue({ error: { message: 'Email not confirmed' } });
+      render(<LoginPage />);
+      fillAndSubmit();
+      await waitFor(() =>
+        expect(screen.getByText(/verified/i)).toBeInTheDocument()
+      );
+    });
+
+    it('shows rate limit message', async () => {
+      mockSignIn.mockResolvedValue({ error: { message: 'Too many requests' } });
+      render(<LoginPage />);
+      fillAndSubmit();
+      await waitFor(() =>
+        expect(screen.getByText(/wait/i)).toBeInTheDocument()
+      );
+    });
+
+    it('shows admin contact message when no account found', async () => {
+      mockSignIn.mockResolvedValue({ error: { message: 'User not found' } });
+      render(<LoginPage />);
+      fillAndSubmit();
+      await waitFor(() =>
+        expect(screen.getByText(/administrator/i)).toBeInTheDocument()
+      );
+    });
+
+    it('handles thrown network errors (not just returned errors)', async () => {
+      mockSignIn.mockRejectedValue(new Error('Failed to fetch'));
+      render(<LoginPage />);
+      fillAndSubmit();
+      await waitFor(() =>
+        expect(screen.getByText(/Unable to reach/i)).toBeInTheDocument()
+      );
+    });
+
+    it('redirects to explorer on success', async () => {
+      const push = vi.fn();
+      vi.mocked(await import('next/navigation')).useRouter = () => ({ push } as ReturnType<typeof import('next/navigation').useRouter>);
+      mockSignIn.mockResolvedValue({ error: null });
+      render(<LoginPage />);
+      fillAndSubmit();
+      await waitFor(() => expect(push).toHaveBeenCalledWith('/explorer'));
+    });
+  });
+
+  describe('password reset errors', () => {
+    function switchToResetMode() {
+      fireEvent.click(screen.getByRole('button', { name: /forgot password/i }));
+    }
+
+    function submitReset(email = 'user@example.com') {
+      fireEvent.change(screen.getByPlaceholderText('you@example.com'), {
+        target: { value: email },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /send reset email/i }));
+    }
+
+    it('shows offline message for Failed to fetch during reset', async () => {
+      mockResetPassword.mockResolvedValue({ error: { message: 'Failed to fetch' } });
+      render(<LoginPage />);
+      switchToResetMode();
+      submitReset();
+      await waitFor(() =>
+        expect(screen.getByText(/Unable to send/i)).toBeInTheDocument()
+      );
+    });
+
+    it('does not show raw "Failed to fetch" during reset', async () => {
+      mockResetPassword.mockResolvedValue({ error: { message: 'Failed to fetch' } });
+      render(<LoginPage />);
+      switchToResetMode();
+      submitReset();
+      await waitFor(() =>
+        expect(screen.queryByText('Failed to fetch')).not.toBeInTheDocument()
+      );
+    });
+
+    it('shows rate limit message during reset', async () => {
+      mockResetPassword.mockResolvedValue({ error: { message: 'over_email_send_rate_limit' } });
+      render(<LoginPage />);
+      switchToResetMode();
+      submitReset();
+      await waitFor(() =>
+        expect(screen.getByText(/wait/i)).toBeInTheDocument()
+      );
+    });
+
+    it('shows success state when reset email sends', async () => {
+      mockResetPassword.mockResolvedValue({ error: null });
+      render(<LoginPage />);
+      switchToResetMode();
+      submitReset();
+      await waitFor(() =>
+        expect(screen.getByText(/reset email sent/i)).toBeInTheDocument()
+      );
+    });
+  });
+});

--- a/src/utils/__tests__/authErrors.test.ts
+++ b/src/utils/__tests__/authErrors.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { getLoginErrorMessage, getPasswordResetErrorMessage } from '../authErrors';
+
+describe('getLoginErrorMessage', () => {
+  describe('network errors', () => {
+    it('maps "Failed to fetch" to an actionable message', () => {
+      const result = getLoginErrorMessage(new Error('Failed to fetch'));
+      expect(result).toContain('Unable to reach');
+      expect(result).toContain('try again');
+    });
+
+    it('maps NetworkError to an actionable message', () => {
+      const result = getLoginErrorMessage(new Error('NetworkError when attempting to fetch resource'));
+      expect(result).toContain('Unable to reach');
+    });
+
+    it('maps "Network request failed" to an actionable message', () => {
+      const result = getLoginErrorMessage(new Error('Network request failed'));
+      expect(result).toContain('Unable to reach');
+    });
+
+    it('does not surface raw "Failed to fetch" to the user', () => {
+      const result = getLoginErrorMessage(new Error('Failed to fetch'));
+      expect(result).not.toBe('Failed to fetch');
+    });
+  });
+
+  describe('invalid credentials', () => {
+    it('maps Supabase invalid login message', () => {
+      const result = getLoginErrorMessage({ message: 'Invalid login credentials' });
+      expect(result).toContain('Incorrect email or password');
+    });
+
+    it('handles lowercase variant', () => {
+      const result = getLoginErrorMessage({ message: 'invalid login credentials' });
+      expect(result).toContain('Incorrect email or password');
+    });
+  });
+
+  describe('email not confirmed', () => {
+    it('maps unconfirmed email error', () => {
+      const result = getLoginErrorMessage({ message: 'Email not confirmed' });
+      expect(result).toContain('verified');
+      expect(result).toContain('inbox');
+    });
+
+    it('maps email_not_confirmed code', () => {
+      const result = getLoginErrorMessage({ message: 'email_not_confirmed' });
+      expect(result).toContain('verified');
+    });
+  });
+
+  describe('rate limiting', () => {
+    it('maps "Too many requests"', () => {
+      const result = getLoginErrorMessage({ message: 'Too many requests' });
+      expect(result).toContain('wait');
+    });
+
+    it('maps over_email_send_rate_limit', () => {
+      const result = getLoginErrorMessage({ message: 'over_email_send_rate_limit' });
+      expect(result).toContain('wait');
+    });
+
+    it('maps rate_limit', () => {
+      const result = getLoginErrorMessage({ message: 'rate_limit exceeded' });
+      expect(result).toContain('wait');
+    });
+  });
+
+  describe('user not found', () => {
+    it('maps user not found to invite-only guidance', () => {
+      const result = getLoginErrorMessage({ message: 'User not found' });
+      expect(result).toContain('administrator');
+    });
+
+    it('maps signup_disabled to invite-only guidance', () => {
+      const result = getLoginErrorMessage({ message: 'signup_disabled' });
+      expect(result).toContain('administrator');
+    });
+  });
+
+  describe('auth disabled', () => {
+    it('maps auth_api_disabled', () => {
+      const result = getLoginErrorMessage({ message: 'auth_api_disabled' });
+      expect(result).toContain('disabled');
+    });
+  });
+
+  describe('fallback', () => {
+    it('passes through unrecognized messages as-is', () => {
+      const result = getLoginErrorMessage({ message: 'Some unexpected supabase error' });
+      expect(result).toBe('Some unexpected supabase error');
+    });
+
+    it('returns a generic message when error has no message', () => {
+      const result = getLoginErrorMessage({});
+      expect(result).toContain('Something went wrong');
+    });
+
+    it('handles null gracefully', () => {
+      const result = getLoginErrorMessage(null);
+      expect(result).toContain('Something went wrong');
+    });
+
+    it('handles plain Error objects', () => {
+      const result = getLoginErrorMessage(new Error('Failed to fetch'));
+      expect(typeof result).toBe('string');
+      expect(result.length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('getPasswordResetErrorMessage', () => {
+  it('maps "Failed to fetch" for reset flow', () => {
+    const result = getPasswordResetErrorMessage(new Error('Failed to fetch'));
+    expect(result).toContain('Unable to send');
+    expect(result).not.toBe('Failed to fetch');
+  });
+
+  it('maps rate limit for reset flow', () => {
+    const result = getPasswordResetErrorMessage({ message: 'over_email_send_rate_limit' });
+    expect(result).toContain('wait');
+  });
+
+  it('maps user not found for reset flow', () => {
+    const result = getPasswordResetErrorMessage({ message: 'User not found' });
+    expect(result).toContain('No account found');
+  });
+
+  it('passes through unrecognized messages', () => {
+    const result = getPasswordResetErrorMessage({ message: 'unexpected error' });
+    expect(result).toBe('unexpected error');
+  });
+});

--- a/src/utils/authErrors.ts
+++ b/src/utils/authErrors.ts
@@ -1,0 +1,71 @@
+type ErrorLike = { message: string } | Error | unknown;
+
+function extractMessage(error: ErrorLike): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    return String((error as { message: unknown }).message);
+  }
+  return '';
+}
+
+export function getLoginErrorMessage(error: ErrorLike): string {
+  const msg = extractMessage(error);
+
+  if (!msg) return 'Something went wrong. Please try again.';
+
+  // Network-level failure — Supabase project paused, no internet, DNS failure, etc.
+  if (msg === 'Failed to fetch' || msg.toLowerCase().includes('networkerror') || msg.toLowerCase().includes('network request failed')) {
+    return 'Unable to reach the sign-in service. The app may be temporarily offline — wait a moment and try again. If this keeps happening, the service may need to be restarted.';
+  }
+
+  // Wrong credentials
+  if (msg === 'Invalid login credentials' || msg.toLowerCase().includes('invalid login')) {
+    return 'Incorrect email or password.';
+  }
+
+  // Email not confirmed
+  if (msg.toLowerCase().includes('email not confirmed') || msg.includes('email_not_confirmed')) {
+    return 'Your email address hasn\'t been verified yet. Check your inbox for a confirmation link.';
+  }
+
+  // Rate limiting
+  if (
+    msg.toLowerCase().includes('too many requests') ||
+    msg.includes('rate_limit') ||
+    msg.includes('over_email_send_rate_limit')
+  ) {
+    return 'Too many attempts — please wait a few minutes before trying again.';
+  }
+
+  // User doesn't exist / signup disabled (invite-only app)
+  if (msg.toLowerCase().includes('user not found') || msg.includes('signup_disabled')) {
+    return 'No account found for that email. Contact your administrator to request access.';
+  }
+
+  // Supabase project-level auth disabled
+  if (msg.includes('auth_api_disabled') || msg.toLowerCase().includes('auth is not enabled')) {
+    return 'Authentication is currently disabled. Please contact support.';
+  }
+
+  return msg;
+}
+
+export function getPasswordResetErrorMessage(error: ErrorLike): string {
+  const msg = extractMessage(error);
+
+  if (!msg) return 'Something went wrong. Please try again.';
+
+  if (msg === 'Failed to fetch' || msg.toLowerCase().includes('networkerror') || msg.toLowerCase().includes('network request failed')) {
+    return 'Unable to send reset email — the service appears to be offline. Please try again shortly.';
+  }
+
+  if (msg.toLowerCase().includes('too many requests') || msg.includes('over_email_send_rate_limit') || msg.includes('rate_limit')) {
+    return 'Too many reset attempts — please wait a few minutes before trying again.';
+  }
+
+  if (msg.toLowerCase().includes('user not found')) {
+    return 'No account found for that email address.';
+  }
+
+  return msg;
+}


### PR DESCRIPTION
## Summary
- Maps `Failed to fetch` to an actionable offline message instead of exposing the raw browser error to the user
- Covers invalid credentials, unconfirmed email, rate limits, user-not-found, and auth-disabled error states
- Wraps both sign-in and password reset in try/catch so thrown errors are handled, not just returned ones

## Changes
- `src/utils/authErrors.ts` — new utility with `getLoginErrorMessage` and `getPasswordResetErrorMessage`
- `app/login/page.tsx` — uses the utility, both handlers now have try/catch

## Test plan
- [x] Sign in with wrong password → `Incorrect email or password.`
- [x] Sign in with DevTools Network set to Offline → `Unable to reach the sign-in service...` (not raw `Failed to fetch`)
- [x] Sign in with valid credentials → redirects to `/explorer`
- [x] Forgot Password with Offline → `Unable to send reset email...`
- [x] Forgot Password with valid email → success state shown
- 34 unit tests passing across utility functions and LoginPage component