### PR TITLE
chore(ci): add Supabase keepalive to prevent free tier pause

### DIFF
--- a/.github/workflows/supabase-keepalive.yml
+++ b/.github/workflows/supabase-keepalive.yml
@@ -1,0 +1,28 @@
+name: Supabase Keepalive
+
+# Supabase free tier pauses projects after 7 days of inactivity.
+# This pings the auth health endpoint twice a week to prevent that.
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Monday 09:00 UTC
+    - cron: '0 9 * * 4'  # Thursday 09:00 UTC
+  workflow_dispatch:      # allow manual trigger
+
+jobs:
+  ping:
+    name: Ping Supabase
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping auth health endpoint
+        run: |
+          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
+            "${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}/auth/v1/health")
+
+          echo "Response: $RESPONSE"
+
+          if [ "$RESPONSE" = "200" ]; then
+            echo "✅ Supabase is healthy"
+          else
+            echo "⚠️ Unexpected response: $RESPONSE"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that pings the Supabase auth health endpoint twice a week (Monday + Thursday at 09:00 UTC)
- Prevents the free tier from pausing due to 7 days of inactivity
- Fails the job with a non-zero exit if Supabase returns anything other than 200, so you'd get a GitHub notification if the project goes down

## Setup required
`NEXT_PUBLIC_SUPABASE_URL` must be set as a GitHub Actions secret in the repo settings. If it's already there from CI, no action needed.

## Why twice a week
Once per week technically satisfies the 7-day limit but leaves no buffer for GitHub Actions scheduling drift. Monday + Thursday keeps it well within the window.